### PR TITLE
feat: add threexui_nodes data source (cluster node tree)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,10 +189,17 @@ normalises both formats to plain strings — rest of the code is unaffected.
 
 ### Data sources
 
-Seven data sources: `inbounds`, `server_status`, `xray_versions`, `xray_config`,
+Eight data sources: `inbounds`, `nodes`, `server_status`, `xray_versions`, `xray_config`,
 `settings`, `online_clients`, `client_traffics`. All are read-only GET wrappers
 that return the raw panel payload — none accept filter arguments. JSON attrs that
 contain secrets (UUIDs, private keys) must be marked `Sensitive: true`.
+
+`threexui_nodes` wraps `GET /panel/api/nodes` (3x-ui multi-node/cluster surface,
+available since v3.0.2; no legacy fallback). The response is a **node tree**
+including transitive sub-nodes (read-only projections with `Id == 0`,
+`transitive == true`). The payload carries each node's `apiToken` and
+`pinnedCertSha256` **raw** (no redaction layer), so the `nodes` attr is
+`Sensitive: true`.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,11 @@ gh pr checks <PR>          # one-shot
 gh pr checks <PR> --watch  # live
 ```
 
+Every PR must end with a **green CI + a clean Codecov report**. The
+`ci.yml` test job uploads coverage to Codecov (`codecov/codecov-action`),
+which then posts a **Patch coverage** comment. Review it as part of the PR:
+see [Testing → Codecov patch coverage](#testing) below for the rule.
+
 **Version-specific acc tests:**
 
 ```bash
@@ -312,6 +317,22 @@ Imperative mood, concise subjects.
   create/update/import round-trip for every protocol.
 - Destroy checks use `destroyVisibilityAttempts` (60 × 500 ms) to handle
   SQLite visibility lag after delete.
+- **Codecov patch coverage is a PR gate.** The `ci.yml` test job uploads
+  `coverage.out` to Codecov, which posts a *Patch coverage* comment on the PR
+  (e.g. `⚠️ Patch coverage is 39% with 28 lines missing`). A red Codecov
+  report must be resolved before merge — do not ignore it. Concretely:
+  - New `provider/*.go` code is **unit-tested**, not only acc-tested. A data
+    source's `Schema`/`Configure`/`Read`, a resource's CRUD methods, and new
+    `Client` methods must each have a direct unit test. Acc tests don't count
+    toward patch coverage and run only with `TF_ACC=1`.
+  - If Codecov flags a line, either cover it with a unit test or, if the line
+    is genuinely unreachable/defensive (e.g. a can't-happen error branch),
+    document why inline. Do **not** merge with a red patch-coverage report
+    just because CI is green — `task test:unit:coverage` reproduces the same
+    numbers locally (`coverage.out`).
+  - Install the Codecov GitHub app on the repo so uploads/comments are
+    processed reliably (the bot warns: *"Please install the 'codecov app svg
+    image'…"* when the app is missing).
 
 ### Pre-commit
 

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -164,6 +164,7 @@ resource "threexui_inbound_client" "client_a" {
 | Data Source | الوصف |
 | --- | --- |
 | `threexui_inbounds` | كل الـ inbounds (JSON، حساس) |
+| `threexui_nodes` | شجرة عقد الكتلة / multi-node (JSON، حساس) |
 | `threexui_server_status` | حالة السيرفر: CPU، الذاكرة، القرص، uptime (JSON) |
 | `threexui_settings` | كل إعدادات اللوحة (JSON، حساس) |
 | `threexui_xray_config` | قالب Xray الحالي (JSON، حساس) |

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -158,6 +158,7 @@ La documentación completa está en el [Terraform Registry](https://registry.ter
 | Data source | Descripción |
 | --- | --- |
 | `threexui_inbounds` | Lista de todos los inbounds (JSON, sensible) |
+| `threexui_nodes` | Árbol de nodos del clúster / multi-node (JSON, sensible) |
 | `threexui_server_status` | Estado del servidor: CPU, memoria, disco, uptime (JSON) |
 | `threexui_settings` | Todos los ajustes del panel (JSON, sensible) |
 | `threexui_xray_config` | Plantilla actual de Xray (JSON, sensible) |

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -164,6 +164,7 @@ resource "threexui_inbound_client" "client_a" {
 | Data Source | توضیح |
 | --- | --- |
 | `threexui_inbounds` | لیست همهٔ اینباندها (JSON، حساس) |
+| `threexui_nodes` | درخت گره‌های کلاستر / multi-node (JSON، حساس) |
 | `threexui_server_status` | وضعیت سرور: CPU، حافظه، دیسک، uptime (JSON) |
 | `threexui_settings` | همهٔ تنظیمات پنل (JSON، حساس) |
 | `threexui_xray_config` | قالب فعلی Xray (JSON، حساس) |

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Full documentation is available on the [Terraform Registry](https://registry.ter
 | Data Source | Description |
 | --- | --- |
 | `threexui_inbounds` | List of all inbounds (JSON, sensitive) |
+| `threexui_nodes` | Cluster node tree / multi-node surface (JSON, sensitive) |
 | `threexui_server_status` | Server status: CPU, memory, disk, uptime (JSON) |
 | `threexui_settings` | All panel settings (JSON, sensitive) |
 | `threexui_xray_config` | Current Xray template (JSON, sensitive) |

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -158,6 +158,7 @@ resource "threexui_inbound_client" "client_a" {
 | Data source | Описание |
 | --- | --- |
 | `threexui_inbounds` | Список всех инбаундов (JSON, sensitive) |
+| `threexui_nodes` | Дерево узлов кластера / multi-node (JSON, sensitive) |
 | `threexui_server_status` | Статус сервера: CPU, память, диск, uptime (JSON) |
 | `threexui_settings` | Все настройки панели (JSON, sensitive) |
 | `threexui_xray_config` | Текущий шаблон Xray (JSON, sensitive) |

--- a/README.tr_TR.md
+++ b/README.tr_TR.md
@@ -158,6 +158,7 @@ Tam belgeler [Terraform Registry](https://registry.terraform.io/providers/batono
 | Veri Kaynağı | Açıklama |
 | --- | --- |
 | `threexui_inbounds` | Tüm inbound'ların listesi (JSON, hassas) |
+| `threexui_nodes` | Küme düğüm ağacı / multi-node (JSON, hassas) |
 | `threexui_server_status` | Sunucu durumu: CPU, bellek, disk, uptime (JSON) |
 | `threexui_settings` | Tüm panel ayarları (JSON, hassas) |
 | `threexui_xray_config` | Geçerli Xray şablonu (JSON, hassas) |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -158,6 +158,7 @@ resource "threexui_inbound_client" "client_a" {
 | Data Source | 说明 |
 | --- | --- |
 | `threexui_inbounds` | 所有 inbound(JSON,敏感) |
+| `threexui_nodes` | 集群节点树 / multi-node（JSON，敏感） |
 | `threexui_server_status` | 服务器状态:CPU、内存、磁盘、uptime(JSON) |
 | `threexui_settings` | 所有面板设置(JSON,敏感) |
 | `threexui_xray_config` | 当前 Xray 模板(JSON,敏感) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,7 @@ The 3x-ui panel issues and stores secrets that this provider reads and writes. T
 | `threexui_panel_email` | `smtp_password` |
 | `threexui_panel_user` | `old_password`, `new_password` |
 | `threexui_xray_outbounds` | per-protocol credentials (e.g. `password`, `users[].password`) |
-| Data sources | `threexui_inbounds.inbounds`, `threexui_settings.json`, `threexui_xray_config.json` (full payloads) |
+| Data sources | `threexui_inbounds.inbounds`, `threexui_nodes.nodes` (`apiToken`, `pinnedCertSha256`), `threexui_settings.json`, `threexui_xray_config.json` (full payloads) |
 
 ## Protecting Terraform State
 

--- a/docs/data-sources/nodes.md
+++ b/docs/data-sources/nodes.md
@@ -1,0 +1,40 @@
+---
+page_title: "threexui_nodes Data Source - 3x-ui"
+subcategory: "Cluster"
+description: |-
+  Retrieves the cluster node tree (3x-ui multi-node surface) registered with the central 3x-ui panel.
+---
+
+# threexui_nodes (Data Source)
+
+Retrieves the cluster node tree registered with the central 3x-ui panel as a JSON string. Corresponds to `GET /panel/api/nodes` (the 3x-ui multi-node/cluster surface, available since 3x-ui v3.0.2).
+
+## Example Usage
+
+```hcl
+data "threexui_nodes" "all" {}
+
+locals {
+  nodes = jsondecode(data.threexui_nodes.all.nodes)
+}
+
+# Node names and addresses are not secrets, so wrap with `nonsensitive()` to
+# expose them in plan output. Sensitivity propagates from the source attribute
+# because the payload also contains apiToken/pinnedCertSha256.
+output "node_names" {
+  value = nonsensitive([for n in local.nodes : n.name])
+}
+```
+
+> **Sensitive payload:** The `nodes` attribute is marked sensitive because each node object contains `apiToken` and `pinnedCertSha256`, which the panel returns **raw without redaction**. Outputs that reference it (or values derived from it) must declare `sensitive = true` or be wrapped in `nonsensitive(...)` for fields that are safe to expose.
+>
+> **Node tree & transitive nodes:** The response is the full node tree. It includes **transitive sub-nodes** surfaced from downstream panels — read-only projections with `id == 0` and `transitive == true` that are not persisted on the central panel. Filter on `transitive != true` when you only want directly-managed nodes.
+
+## Argument Reference
+
+This data source has no arguments.
+
+## Attribute Reference
+
+- `id` (String) - ID derived from the first node (`0` when the cluster has no nodes).
+- `nodes` (String, Sensitive) - JSON-encoded array of cluster node objects. Use `jsondecode()` to work with the data. Each object contains managed fields (`name`, `address`, `port`, `scheme`, `basePath`, `enable`, `tlsVerifyMode`, `inboundSyncMode`, `inboundTags`, `outboundTag`, …) and observed state (`status`, `lastHeartbeat`, `latencyMs`, `xrayVersion`, `panelVersion`, `cpuPct`, `memPct`, `xrayState`, `xrayError`, counts, …), plus `apiToken`/`pinnedCertSha256` (sensitive, raw).

--- a/provider/client.go
+++ b/provider/client.go
@@ -566,6 +566,19 @@ func (c *Client) GetInbounds(ctx context.Context) ([]Inbound, error) {
 	return out, nil
 }
 
+// GetNodes lists the cluster node tree registered with the central panel
+// (3x-ui multi-node surface, /panel/api/nodes). The response is a tree that
+// includes transitive sub-nodes (read-only projections with Id == 0 and
+// Transitive == true). Available since 3x-ui v3.0.2; there is no legacy
+// fallback path, so no API-surface auto-detection is needed.
+func (c *Client) GetNodes(ctx context.Context) ([]Node, error) {
+	var out []Node
+	if err := c.doJSON(ctx, http.MethodGet, "panel/api/nodes", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *Client) AddInboundClient(ctx context.Context, inboundID int, client map[string]any) error {
 	if inboundID == 0 {
 		return errors.New("inbound id is required for add client")

--- a/provider/data_source_nodes.go
+++ b/provider/data_source_nodes.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &NodesDataSource{}
+
+type NodesDataSource struct {
+	client *Client
+}
+
+type NodesDataSourceModel struct {
+	ID    types.String `tfsdk:"id"`
+	Nodes types.String `tfsdk:"nodes"`
+}
+
+func NewNodesDataSource() datasource.DataSource {
+	return &NodesDataSource{}
+}
+
+func (d *NodesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_nodes"
+}
+
+func (d *NodesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"nodes": schema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "JSON array of cluster node objects (3x-ui multi-node surface, GET /panel/api/nodes). Marked Sensitive because the payload includes each node's apiToken and pinnedCertSha256, which the panel returns raw without redaction. The array is the full node tree, including transitive sub-nodes surfaced from downstream panels (objects with id == 0 and transitive == true, which are read-only projections).",
+			},
+		},
+	}
+}
+
+func (d *NodesDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type", "Expected *Client")
+		return
+	}
+	d.client = client
+}
+
+func (d *NodesDataSource) Read(ctx context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	nodes, err := d.client.GetNodes(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to list cluster nodes", err.Error())
+		return
+	}
+
+	// The nodes payload intentionally includes each node's apiToken/pinnedCertSha256
+	// (raw, no upstream redaction); the `nodes` attribute is Sensitive so Terraform
+	// never prints it. G117 flags marshaling a struct with a secret-named field —
+	// exposure here is by design, matching the existing threexui_inbounds pattern.
+	payload, err := json.Marshal(nodes) //nolint:gosec // G117: intentional, attr is Sensitive
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to marshal cluster nodes", err.Error())
+		return
+	}
+
+	var state NodesDataSourceModel
+	state.Nodes = types.StringValue(string(payload))
+	if len(nodes) == 0 {
+		state.ID = types.StringValue("0")
+	} else {
+		state.ID = types.StringValue(strconv.Itoa(nodes[0].Id))
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/provider/data_source_nodes_test.go
+++ b/provider/data_source_nodes_test.go
@@ -1,0 +1,129 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGetNodes verifies the client decodes the 3x-ui multi-node tree
+// (GET /panel/api/nodes), including the managed fields and a transitive
+// sub-node (read-only projection surfaced from a downstream panel).
+func TestGetNodes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes":
+			// A direct node plus a transitive sub-node (Id == 0, read-only).
+			w.Write(okResponse([]any{
+				map[string]any{
+					"id":              1,
+					"name":            "de-fra-1",
+					"remark":          "Frankfurt",
+					"scheme":          "https",
+					"address":         "node1.example.com",
+					"port":            2053,
+					"basePath":        "/",
+					"apiToken":        "abcdef0123456789",
+					"enable":          true,
+					"tlsVerifyMode":   "verify",
+					"inboundSyncMode": "all",
+					"inboundTags":     []any{},
+					"outboundTag":     "",
+					"guid":            "11111111-1111-1111-1111-111111111111",
+					"status":          "online",
+					"latencyMs":       42,
+					"xrayVersion":     "25.10.31",
+					"panelVersion":    "v3.4.1",
+					"transitive":      false,
+					"inboundCount":    5,
+					"clientCount":     27,
+				},
+				map[string]any{
+					"id":         0,
+					"name":       "de-fra-1-sub",
+					"address":    "10.0.0.2",
+					"port":       2053,
+					"guid":       "22222222-2222-2222-2222-222222222222",
+					"parentGuid": "11111111-1111-1111-1111-111111111111",
+					"transitive": true,
+					"status":     "online",
+				},
+			}))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	nodes, err := client.GetNodes(context.Background())
+	if err != nil {
+		t.Fatalf("GetNodes error: %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+
+	direct := nodes[0]
+	if direct.Id != 1 || direct.Name != "de-fra-1" || direct.Address != "node1.example.com" {
+		t.Fatalf("unexpected direct node: %+v", direct)
+	}
+	if direct.Port != 2053 || direct.Scheme != "https" || direct.BasePath != "/" {
+		t.Fatalf("unexpected direct node connection fields: %+v", direct)
+	}
+	if direct.ApiToken != "abcdef0123456789" {
+		t.Fatalf("expected raw apiToken to round-trip, got %q", direct.ApiToken)
+	}
+	if direct.TlsVerifyMode != "verify" || direct.InboundSyncMode != "all" {
+		t.Fatalf("unexpected managed fields: %+v", direct)
+	}
+	if direct.Status != "online" || direct.LatencyMs != 42 || direct.XrayVersion != "25.10.31" {
+		t.Fatalf("unexpected observed fields: %+v", direct)
+	}
+	if direct.Transitive {
+		t.Fatalf("direct node must not be transitive")
+	}
+
+	transitive := nodes[1]
+	if transitive.Id != 0 || !transitive.Transitive {
+		t.Fatalf("expected transitive sub-node with Id==0, got %+v", transitive)
+	}
+	if transitive.ParentGuid != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("unexpected parentGuid: %q", transitive.ParentGuid)
+	}
+}
+
+// TestGetNodesEmpty verifies the cluster-with-no-nodes case (fresh panel).
+func TestGetNodesEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes":
+			w.Write(okResponse([]any{}))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	nodes, err := client.GetNodes(context.Background())
+	if err != nil {
+		t.Fatalf("GetNodes error: %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Fatalf("expected 0 nodes on fresh panel, got %d", len(nodes))
+	}
+}

--- a/provider/data_source_schema_test.go
+++ b/provider/data_source_schema_test.go
@@ -19,6 +19,7 @@ func TestDataSourceSensitiveAttributes(t *testing.T) {
 		attribute string
 	}{
 		{"inbounds", NewInboundsDataSource, "inbounds"},
+		{"nodes", NewNodesDataSource, "nodes"},
 		{"settings", NewSettingsDataSource, "json"},
 		{"xray_config", NewXrayConfigDataSource, "json"},
 	}

--- a/provider/data_source_test.go
+++ b/provider/data_source_test.go
@@ -152,6 +152,104 @@ func dsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
+// Nodes data source (cluster node tree)
+// ---------------------------------------------------------------------------
+
+func TestNodesDataSource_Read(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/panel/api/nodes" {
+			w.Write(okResponse([]any{
+				map[string]any{
+					"id":         1,
+					"name":       "de-fra-1",
+					"address":    "node1.example.com",
+					"port":       2053,
+					"apiToken":   "secret-token",
+					"enable":     true,
+					"guid":       "11111111-1111-1111-1111-111111111111",
+					"status":     "online",
+					"transitive": false,
+				},
+			}))
+			return
+		}
+		dsHandler(w, r)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	ds := &NodesDataSource{client: client}
+	resp := newDSReadResponse(t, ds)
+	ds.Read(context.Background(), datasource.ReadRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected errors: %v", resp.Diagnostics)
+	}
+
+	var state NodesDataSourceModel
+	resp.State.Get(context.Background(), &state)
+	if state.ID.ValueString() != "1" {
+		t.Fatalf("expected id 1, got %s", state.ID.ValueString())
+	}
+	if state.Nodes.IsNull() {
+		t.Fatal("expected nodes to be set")
+	}
+	// Raw payload must contain the sensitive apiToken (Sensitive attr, not redacted).
+	if !contains(state.Nodes.ValueString(), "secret-token") {
+		t.Fatalf("expected raw payload to contain apiToken, got %s", state.Nodes.ValueString())
+	}
+}
+
+func TestNodesDataSource_Read_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/panel/api/nodes" {
+			w.Write(okResponse([]any{}))
+			return
+		}
+		dsHandler(w, r)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	ds := &NodesDataSource{client: client}
+	resp := newDSReadResponse(t, ds)
+	ds.Read(context.Background(), datasource.ReadRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected errors: %v", resp.Diagnostics)
+	}
+
+	var state NodesDataSourceModel
+	resp.State.Get(context.Background(), &state)
+	if state.ID.ValueString() != "0" {
+		t.Fatalf("expected id 0 for empty cluster, got %s", state.ID.ValueString())
+	}
+	if state.Nodes.ValueString() != "[]" {
+		t.Fatalf("expected empty JSON array, got %s", state.Nodes.ValueString())
+	}
+}
+
+func TestNodesDataSource_Read_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/panel/api/nodes" {
+			w.Write(failResponse("boom"))
+			return
+		}
+		dsHandler(w, r)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	ds := &NodesDataSource{client: client}
+	resp := newDSReadResponse(t, ds)
+	ds.Read(context.Background(), datasource.ReadRequest{}, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error, got none")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // ServerStatus data source
 // ---------------------------------------------------------------------------
 
@@ -504,6 +602,7 @@ func TestDataSourceMetadata(t *testing.T) {
 		{NewInboundsDataSource(), "threexui_inbounds"},
 		{NewSettingsDataSource(), "threexui_settings"},
 		{NewXrayConfigDataSource(), "threexui_xray_config"},
+		{NewNodesDataSource(), "threexui_nodes"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.expected, func(t *testing.T) {
@@ -542,6 +641,8 @@ func TestDataSourceConfigure(t *testing.T) {
 			d.Configure(context.Background(), req, &resp)
 		case *XrayConfigDataSource:
 			d.Configure(context.Background(), req, &resp)
+		case *NodesDataSource:
+			d.Configure(context.Background(), req, &resp)
 		default:
 			t.Fatalf("unhandled data source type: %T", ds)
 		}
@@ -559,6 +660,7 @@ func TestDataSourceConfigure(t *testing.T) {
 		{"inbounds", NewInboundsDataSource()},
 		{"settings", NewSettingsDataSource()},
 		{"xray_config", NewXrayConfigDataSource()},
+		{"nodes", NewNodesDataSource()},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -301,6 +301,7 @@ func (p *ThreeXUIProvider) Resources(_ context.Context) []func() resource.Resour
 func (p *ThreeXUIProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewInboundsDataSource,
+		NewNodesDataSource,
 		NewServerStatusDataSource,
 		NewXrayVersionsDataSource,
 		NewXrayConfigDataSource,

--- a/provider/quickwins_schema_test.go
+++ b/provider/quickwins_schema_test.go
@@ -30,8 +30,8 @@ func TestProviderResources(t *testing.T) {
 func TestProviderDataSources(t *testing.T) {
 	p := &ThreeXUIProvider{}
 	dataSources := p.DataSources(context.Background())
-	if len(dataSources) != 7 {
-		t.Fatalf("expected 7 data sources, got %d", len(dataSources))
+	if len(dataSources) != 8 {
+		t.Fatalf("expected 8 data sources, got %d", len(dataSources))
 	}
 }
 

--- a/provider/types.go
+++ b/provider/types.go
@@ -92,6 +92,63 @@ type ClientTraffic struct {
 	LastOnline int64  `json:"lastOnline"`
 }
 
+// Node represents a 3x-ui cluster node (model.Node): a remote 3x-ui panel
+// registered with the central panel for multi-node/cluster management.
+//
+// Managed fields (user-editable via the threexui_node resource, see M2) are the
+// top block; the rest are observed state populated by the central panel's
+// heartbeat probes. ApiToken and PinnedCertSha256 are sensitive and returned
+// raw by the panel (no redaction layer), so callers must keep them marked
+// Sensitive in Terraform schemas.
+//
+// Available since 3x-ui v3.0.2; /panel/api/nodes has no legacy fallback path.
+type Node struct {
+	// Managed (user-editable).
+	Id                  int      `json:"id"`
+	Name                string   `json:"name"`
+	Remark              string   `json:"remark"`
+	Scheme              string   `json:"scheme"`
+	Address             string   `json:"address"`
+	Port                int      `json:"port"`
+	BasePath            string   `json:"basePath"`
+	ApiToken            string   `json:"apiToken"`
+	Enable              bool     `json:"enable"`
+	AllowPrivateAddress bool     `json:"allowPrivateAddress"`
+	TlsVerifyMode       string   `json:"tlsVerifyMode"`
+	PinnedCertSha256    string   `json:"pinnedCertSha256"`
+	InboundSyncMode     string   `json:"inboundSyncMode"`
+	InboundTags         []string `json:"inboundTags"`
+	OutboundTag         string   `json:"outboundTag"`
+
+	// Observed identity / heartbeat state (read-only).
+	Guid          string  `json:"guid"`
+	Status        string  `json:"status"`
+	LastHeartbeat int64   `json:"lastHeartbeat"`
+	LatencyMs     int     `json:"latencyMs"`
+	XrayVersion   string  `json:"xrayVersion"`
+	PanelVersion  string  `json:"panelVersion"`
+	CpuPct        float64 `json:"cpuPct"`
+	MemPct        float64 `json:"memPct"`
+	UptimeSecs    uint64  `json:"uptimeSecs"`
+	NetUp         uint64  `json:"netUp"`
+	NetDown       uint64  `json:"netDown"`
+	LastError     string  `json:"lastError"`
+	XrayState     string  `json:"xrayState"`
+	XrayError     string  `json:"xrayError"`
+	ConfigDirty   bool    `json:"configDirty"`
+	ConfigDirtyAt int64   `json:"configDirtyAt"`
+	InboundCount  int     `json:"inboundCount"`
+	ClientCount   int     `json:"clientCount"`
+	OnlineCount   int     `json:"onlineCount"`
+	ActiveCount   int     `json:"activeCount"`
+	DisabledCount int     `json:"disabledCount"`
+	DepletedCount int     `json:"depletedCount"`
+	ParentGuid    string  `json:"parentGuid,omitempty"`
+	Transitive    bool    `json:"transitive,omitempty"`
+	CreatedAt     int64   `json:"createdAt"`
+	UpdatedAt     int64   `json:"updatedAt"`
+}
+
 // ParseJSONField decodes a JSON string into a generic map.
 func ParseJSONField(value string) (map[string]any, error) {
 	var out map[string]any


### PR DESCRIPTION
## Summary

First deliverable (M1) of the **Multi-node (cluster) management** milestone (#4).

Adds a read-only `threexui_nodes` data source wrapping `GET /panel/api/nodes` — the 3x-ui multi-node/cluster surface. The provider could already bind inbounds to nodes (`threexui_inbound.node_id`) but could not read the cluster topology; this fills that read gap. The write side (resource) is M2 (#317).

Research that unblocked this is in #314 (closed): the nodes API exists since **3x-ui v3.0.2** (no version gate, no legacy fallback) and `apiToken`/`pinnedCertSha256` are returned **raw** (no redaction layer).

## Changes
- `provider/types.go` — typed `Node` model (full field set, reused by the upcoming resource).
- `provider/client.go` — `GetNodes` mirroring `GetInbounds` (`/panel/api/nodes`).
- `provider/data_source_nodes.go` — `threexui_nodes` data source (Sensitive JSON payload, no args — matches the existing 7 data sources' convention).
- `provider/data_source_nodes_test.go` — decode tests (direct + transitive node, empty cluster).
- `provider/data_source_schema_test.go`, `provider/quickwins_schema_test.go` — count/sensitive guards updated (7→8 data sources).
- `provider/provider.go` — registration.
- `docs/data-sources/nodes.md` + 7 README locales + `AGENTS.md`.

## Checks
- `go vet ./provider/`, `golangci-lint run ./provider/`, `go test ./provider/` — green locally.
- The `gosec` G117 on `json.Marshal(nodes)` is suppressed with a scoped `//nolint` + justification: exposing the nodes payload (incl. raw `apiToken`) is intentional and the `nodes` attribute is `Sensitive`, matching the existing `threexui_inbounds` pattern.
- Pre-commit (fmt/vet/lint/build/markdownlint) passed.
- Acc-test for the data source will be added once the node resource (M2) can seed a node; for now the data source over an empty cluster returns `[]` (covered by `TestGetNodesEmpty`).

Closes #316.
