### PR TITLE
feat: add threexui_node resource (Create/Read/Import) for cluster nodes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,26 @@ prior state credentials (falls back to provider credentials when state
 password is empty, e.g. after using `password_wo`). See Write-only section
 above for the `password` / `password_wo` lifecycle.
 
+### Cluster node (`resource_node.go`)
+
+`threexui_node` — manages a remote 3x-ui panel registered as a cluster node
+(multi-node surface, `/panel/api/nodes`; available since v3.0.2, no legacy
+fallback). Create does a form-POST `/panel/api/nodes`; the **central panel
+probes the node for reachability (`ensureReachable`) before persisting it**, so
+the node's web API must be reachable from the central panel at apply time —
+there is no provider-side flag to bypass this (decided in #315). Read does
+`GET /panel/api/nodes/:id` and treats HTTP 404 as remove-from-state. Import is
+by numeric id (`ImportStatePassthroughID`). **Update and Delete are M2
+placeholders** (warning, no server change); real update (form-POST
+`/panel/api/nodes/:id` + Xray restart on `outbound_tag` change — the server
+already restarts on `outbound_tag` change per `controller/node.go:180-181`, so
+the provider only needs to POST) and real delete (DELETE, which 3x-ui refuses
+when inbounds are still attached — DB-002, #314 R3) are M3 (#318). `api_token`
+and `pinned_cert_sha256` are `Sensitive` (the panel returns them raw, no
+redaction — #314 R1); write-only `_wo` variants are M4 (#319). Schema lives in
+`node_schema.go`; the typed `Node` model is shared with the `threexui_nodes`
+data source (`types.go`).
+
 ### HTTP client (`client.go`)
 
 Cookie auth, auto re-login on 401/404, CSRF token handling (enforced on all

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,15 +171,17 @@ above for the `password` / `password_wo` lifecycle.
 ### Cluster node (`resource_node.go`)
 
 `threexui_node` — manages a remote 3x-ui panel registered as a cluster node
-(multi-node surface, `/panel/api/nodes`; available since v3.0.2, no legacy
-fallback). Create does a form-POST `/panel/api/nodes`; the **central panel
+(multi-node surface, `/panel/api/nodes/*`; available since v3.0.2, no legacy
+fallback). Create does a form-POST `/panel/api/nodes/add`; the **central panel
 probes the node for reachability (`ensureReachable`) before persisting it**, so
 the node's web API must be reachable from the central panel at apply time —
 there is no provider-side flag to bypass this (decided in #315). Read does
-`GET /panel/api/nodes/:id` and treats HTTP 404 as remove-from-state. Import is
+`GET /panel/api/nodes/get/:id` and treats a missing node (the panel signals
+this as HTTP 200 + `success:false` with a gorm "record not found" message,
+NOT HTTP 404 — see `util.go jsonMsgObj`) as remove-from-state. Import is
 by numeric id (`ImportStatePassthroughID`). **Update and Delete are M2
 placeholders** (warning, no server change); real update (form-POST
-`/panel/api/nodes/:id` + Xray restart on `outbound_tag` change — the server
+`/panel/api/nodes/update/:id` + Xray restart on `outbound_tag` change — the server
 already restarts on `outbound_tag` change per `controller/node.go:180-181`, so
 the provider only needs to POST) and real delete (DELETE, which 3x-ui refuses
 when inbounds are still attached — DB-002, #314 R3) are M3 (#318). `api_token`
@@ -219,7 +221,7 @@ Eight data sources: `inbounds`, `nodes`, `server_status`, `xray_versions`, `xray
 that return the raw panel payload — none accept filter arguments. JSON attrs that
 contain secrets (UUIDs, private keys) must be marked `Sensitive: true`.
 
-`threexui_nodes` wraps `GET /panel/api/nodes` (3x-ui multi-node/cluster surface,
+`threexui_nodes` wraps `GET /panel/api/nodes/list` (3x-ui multi-node/cluster surface,
 available since v3.0.2; no legacy fallback). The response is a **node tree**
 including transitive sub-nodes (read-only projections with `Id == 0`,
 `transitive == true`). The payload carries each node's `apiToken` and

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -145,6 +145,7 @@ resource "threexui_inbound_client" "client_a" {
 | --- | --- |
 | `threexui_inbound` | inbound (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria؛ socks/dokodemo-door legacy قبل 3.2) |
 | `threexui_inbound_client` | عميل داخل inbound |
+| `threexui_node` | عقدة الكتلة / تسجيل multi-node (Create/Read/Import) |
 | `threexui_panel_general` | إعدادات اللوحة العامة |
 | `threexui_panel_security` | إعدادات الأمان (2FA) |
 | `threexui_panel_user` | بيانات اعتماد المسؤول |

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -139,6 +139,7 @@ La documentación completa está en el [Terraform Registry](https://registry.ter
 | --- | --- |
 | `threexui_inbound` | Inbound (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; socks/dokodemo-door legacy antes de 3.2) |
 | `threexui_inbound_client` | Cliente dentro de un inbound |
+| `threexui_node` | Nodo del clúster / registro multi-node (Create/Read/Import) |
 | `threexui_panel_general` | Ajustes generales del panel |
 | `threexui_panel_security` | Ajustes de seguridad (2FA) |
 | `threexui_panel_user` | Credenciales de administrador |

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -145,6 +145,7 @@ resource "threexui_inbound_client" "client_a" {
 | --- | --- |
 | `threexui_inbound` | اینباند (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria؛ socks/dokodemo-door در نسخه‌های قبل از 3.2 به‌صورت legacy) |
 | `threexui_inbound_client` | کلاینت داخل اینباند |
+| `threexui_node` | گره کلاستر / ثبت multi-node (Create/Read/Import) |
 | `threexui_panel_general` | تنظیمات عمومی پنل |
 | `threexui_panel_security` | تنظیمات امنیت (2FA) |
 | `threexui_panel_user` | اعتبارنامه‌های ادمین |

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Full documentation is available on the [Terraform Registry](https://registry.ter
 | --- | --- |
 | `threexui_inbound` | Inbound proxy (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; legacy socks/dokodemo-door before 3.2) |
 | `threexui_inbound_client` | Client within an inbound |
+| `threexui_node` | Cluster node / multi-node registration (Create/Read/Import) |
 | `threexui_panel_general` | General panel settings |
 | `threexui_panel_security` | Security settings (2FA) |
 | `threexui_panel_user` | Admin credentials |

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -139,6 +139,7 @@ resource "threexui_inbound_client" "client_a" {
 | --- | --- |
 | `threexui_inbound` | Инбаунд (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; legacy socks/dokodemo-door до 3.2) |
 | `threexui_inbound_client` | Клиент внутри инбаунда |
+| `threexui_node` | Узел кластера / регистрация multi-node (Create/Read/Import) |
 | `threexui_panel_general` | Общие настройки панели |
 | `threexui_panel_security` | Безопасность (2FA) |
 | `threexui_panel_user` | Учётные данные администратора |

--- a/README.tr_TR.md
+++ b/README.tr_TR.md
@@ -139,6 +139,7 @@ Tam belgeler [Terraform Registry](https://registry.terraform.io/providers/batono
 | --- | --- |
 | `threexui_inbound` | Inbound proxy (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; 3.2 öncesi legacy socks/dokodemo-door) |
 | `threexui_inbound_client` | Bir inbound içindeki istemci |
+| `threexui_node` | Küme düğümü / multi-node kaydı (Create/Read/Import) |
 | `threexui_panel_general` | Genel panel ayarları |
 | `threexui_panel_security` | Güvenlik ayarları (2FA) |
 | `threexui_panel_user` | Yönetici kimlik bilgileri |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -139,6 +139,7 @@ resource "threexui_inbound_client" "client_a" {
 | --- | --- |
 | `threexui_inbound` | inbound 代理(vless、vmess、trojan、shadowsocks、http、mixed、wireguard、tunnel、hysteria；3.2 之前兼容 legacy socks/dokodemo-door) |
 | `threexui_inbound_client` | inbound 内的客户端 |
+| `threexui_node` | 集群节点 / multi-node 注册（Create/Read/Import） |
 | `threexui_panel_general` | 面板通用设置 |
 | `threexui_panel_security` | 安全设置(2FA) |
 | `threexui_panel_user` | 管理员凭据 |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,7 @@ The 3x-ui panel issues and stores secrets that this provider reads and writes. T
 | `threexui_panel_telegram` | `bot_token`, `chat_id` |
 | `threexui_panel_email` | `smtp_password` |
 | `threexui_panel_user` | `old_password`, `new_password` |
+| `threexui_node` | `api_token`, `pinned_cert_sha256` |
 | `threexui_xray_outbounds` | per-protocol credentials (e.g. `password`, `users[].password`) |
 | Data sources | `threexui_inbounds.inbounds`, `threexui_nodes.nodes` (`apiToken`, `pinnedCertSha256`), `threexui_settings.json`, `threexui_xray_config.json` (full payloads) |
 

--- a/docs/data-sources/nodes.md
+++ b/docs/data-sources/nodes.md
@@ -7,7 +7,7 @@ description: |-
 
 # threexui_nodes (Data Source)
 
-Retrieves the cluster node tree registered with the central 3x-ui panel as a JSON string. Corresponds to `GET /panel/api/nodes` (the 3x-ui multi-node/cluster surface, available since 3x-ui v3.0.2).
+Retrieves the cluster node tree registered with the central 3x-ui panel as a JSON string. Corresponds to `GET /panel/api/nodes/list` (the 3x-ui multi-node/cluster surface, available since 3x-ui v3.0.2).
 
 ## Example Usage
 

--- a/docs/resources/node.md
+++ b/docs/resources/node.md
@@ -1,0 +1,82 @@
+---
+page_title: "threexui_node Resource - 3x-ui"
+subcategory: "Cluster"
+description: |-
+  Manages a remote 3x-ui panel registered as a cluster node (3x-ui multi-node surface).
+---
+
+# threexui_node (Resource)
+
+Manages a remote 3x-ui panel registered as a cluster node on the central panel. Wraps the 3x-ui multi-node API (`/panel/api/nodes`), available since 3x-ui v3.0.2.
+
+> **Reachability constraint:** The central panel probes the node for reachability (`ensureReachable`) during create/update before persisting it. The node's web API **must be reachable from the central panel at apply time**, otherwise the create/update fails. There is no way to bypass this from the provider — it is inherent to the 3x-ui server flow.
+>
+> **Scope (M2):** This resource implements **Create + Read + Import**. **In-place Update and Delete are placeholders** that emit a warning and do not change the node on the panel; they are implemented in M3 (#318). To change a node today, change `name`/`address` (forces replacement) or recreate the resource. Write-only secrets (`api_token_wo`) are M4 (#319).
+
+## Example Usage
+
+```hcl
+resource "threexui_node" "fra1" {
+  name        = "de-fra-1"
+  remark      = "Frankfurt edge"
+  scheme      = "https"
+  address     = "node1.example.com"
+  port        = 2053
+  base_path   = "/"
+  api_token   = var.fra1_api_token
+  enable      = true
+
+  tls_verify_mode = "verify"
+}
+```
+
+Import an existing node by its numeric id:
+
+```bash
+terraform import threexui_node.fra1 7
+```
+
+## Argument Reference
+
+- `name` (Required, String) - Unique node name (upstream `uniqueIndex`). Changing this forces a new resource.
+- `address` (Required, String) - Node host. Changing this forces a new resource.
+- `port` (Required, Number) - Node web API port, 1-65535.
+- `remark` (Optional, String) - Free-form note.
+- `scheme` (Optional, String) - `http` or `https`. Defaults to `https`.
+- `base_path` (Optional, String) - Node web API base path. Defaults to `/`.
+- `api_token` (Optional, String, Sensitive) - Bearer API token the central panel uses to authenticate to the node. Required unless `tls_verify_mode` is `mtls`. The panel returns this raw without redaction.
+- `enable` (Optional, Bool) - Whether the node is enabled. Defaults to `true`.
+- `allow_private_address` (Optional, Bool) - Allow the node address to resolve to a private IP. Defaults to `false`.
+- `tls_verify_mode` (Optional, String) - `verify`, `skip`, `pin`, or `mtls`. Defaults to `verify`.
+- `pinned_cert_sha256` (Optional, String, Sensitive) - Pinned certificate fingerprint, required when `tls_verify_mode` is `pin`.
+- `inbound_sync_mode` (Optional, String) - `all` or `selected`. Defaults to `all`.
+- `inbound_tags` (Optional, List of String) - Inbound tags to sync when `inbound_sync_mode` is `selected`.
+- `outbound_tag` (Optional, String) - Xray outbound/balancer tag bridging this node.
+
+## Attribute Reference
+
+In addition to the arguments above, the following observed-state attributes are read-only (`Computed`):
+
+- `id` (String) - Numeric node id (as a string). Import key.
+- `guid` (String) - Remote panel stable GUID.
+- `status` (String) - `online`, `offline`, or `unknown`.
+- `last_heartbeat` (Number) - Unix seconds of the last successful heartbeat (0 = never).
+- `latency_ms` (Number) - Last heartbeat latency in ms.
+- `xray_version` (String) - Xray version reported by the node.
+- `panel_version` (String) - 3x-ui panel version reported by the node.
+- `cpu_pct` / `mem_pct` (Number) - Node CPU / memory usage percent.
+- `uptime_secs` / `net_up` / `net_down` (Number) - Uptime (s) and network byte counters.
+- `last_error` (String) - Last heartbeat error message.
+- `xray_state` / `xray_error` (String) - Xray core state / error from the node.
+- `config_dirty` (Bool) / `config_dirty_at` (Number) - Whether the node config differs from the central panel.
+- `inbound_count` / `client_count` / `online_count` / `active_count` / `disabled_count` / `depleted_count` (Number) - Client/inbound counts.
+- `parent_guid` (String) / `transitive` (Bool) - Node-tree attribution (read-only transitive sub-nodes have `transitive = true`).
+- `created_at` / `updated_at` (Number) - Unix millis.
+
+## Import
+
+Import is supported by numeric id:
+
+```bash
+terraform import threexui_node.NAME <id>
+```

--- a/docs/resources/node.md
+++ b/docs/resources/node.md
@@ -7,7 +7,7 @@ description: |-
 
 # threexui_node (Resource)
 
-Manages a remote 3x-ui panel registered as a cluster node on the central panel. Wraps the 3x-ui multi-node API (`/panel/api/nodes`), available since 3x-ui v3.0.2.
+Manages a remote 3x-ui panel registered as a cluster node on the central panel. Wraps the 3x-ui multi-node API (`/panel/api/nodes/*`), available since 3x-ui v3.0.2.
 
 > **Reachability constraint:** The central panel probes the node for reachability (`ensureReachable`) during create/update before persisting it. The node's web API **must be reachable from the central panel at apply time**, otherwise the create/update fails. There is no way to bypass this from the provider — it is inherent to the 3x-ui server flow.
 >

--- a/provider/client.go
+++ b/provider/client.go
@@ -573,7 +573,7 @@ func (c *Client) GetInbounds(ctx context.Context) ([]Inbound, error) {
 // fallback path, so no API-surface auto-detection is needed.
 func (c *Client) GetNodes(ctx context.Context) ([]Node, error) {
 	var out []Node
-	if err := c.doJSON(ctx, http.MethodGet, "panel/api/nodes", nil, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, "panel/api/nodes/list", nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -588,14 +588,14 @@ func (c *Client) GetNode(ctx context.Context, id int) (*Node, error) {
 		return nil, errors.New("node id is required")
 	}
 	var out Node
-	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("panel/api/nodes/%d", id), nil, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("panel/api/nodes/get/%d", id), nil, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil
 }
 
 // CreateNode registers a remote 3x-ui panel as a cluster node on the central
-// panel (POST /panel/api/nodes). The central panel probes the node for
+// panel (POST /panel/api/nodes/add). The central panel probes the node for
 // reachability (ensureReachable) before persisting it, so the node's web API
 // must be reachable from the central panel during apply. Returns the created
 // node (the controller echoes back the bound model.Node).
@@ -604,7 +604,7 @@ func (c *Client) CreateNode(ctx context.Context, n *Node) (*Node, error) {
 		return nil, errors.New("node is nil")
 	}
 	var out Node
-	if err := c.doForm(ctx, http.MethodPost, "panel/api/nodes", nodeToForm(n), &out); err != nil {
+	if err := c.doForm(ctx, http.MethodPost, "panel/api/nodes/add", nodeToForm(n), &out); err != nil {
 		return nil, err
 	}
 	return &out, nil
@@ -1588,4 +1588,16 @@ func isHTTPNotFound(err error) bool {
 		return true
 	}
 	return false
+}
+
+// isAPIRecordNotFound reports whether the panel reported a missing record.
+// 3x-ui handlers wrap gorm errors into an HTTP 200 success:false envelope
+// (util.go jsonMsgObj), so a missing node surfaces as a request-failed error
+// whose message contains the gorm "record not found" text — not as HTTP 404.
+func isAPIRecordNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "record not found") || strings.Contains(msg, "no rows")
 }

--- a/provider/client.go
+++ b/provider/client.go
@@ -579,6 +579,80 @@ func (c *Client) GetNodes(ctx context.Context) ([]Node, error) {
 	return out, nil
 }
 
+// GetNode fetches a single cluster node by its numeric id
+// (GET /panel/api/nodes/:id). Used by the threexui_node resource for
+// read-after-create and import. Returns ErrNotFound when the node does not
+// exist (central panel responds 404 / error envelope).
+func (c *Client) GetNode(ctx context.Context, id int) (*Node, error) {
+	if id == 0 {
+		return nil, errors.New("node id is required")
+	}
+	var out Node
+	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("panel/api/nodes/%d", id), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateNode registers a remote 3x-ui panel as a cluster node on the central
+// panel (POST /panel/api/nodes). The central panel probes the node for
+// reachability (ensureReachable) before persisting it, so the node's web API
+// must be reachable from the central panel during apply. Returns the created
+// node (the controller echoes back the bound model.Node).
+func (c *Client) CreateNode(ctx context.Context, n *Node) (*Node, error) {
+	if n == nil {
+		return nil, errors.New("node is nil")
+	}
+	var out Node
+	if err := c.doForm(ctx, http.MethodPost, "panel/api/nodes", nodeToForm(n), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// nodeToForm builds the application/x-www-form-urlencoded body for node
+// create/update, mirroring the form tags on model.Node in 3x-ui. inboundTags
+// is serialized to a JSON string (gorm json serializer on the upstream side).
+func nodeToForm(in *Node) url.Values {
+	form := url.Values{}
+	if in == nil {
+		return form
+	}
+	form.Set("name", in.Name)
+	form.Set("remark", in.Remark)
+	if in.Scheme != "" {
+		form.Set("scheme", in.Scheme)
+	}
+	form.Set("address", in.Address)
+	form.Set("port", strconv.Itoa(in.Port))
+	if in.BasePath != "" {
+		form.Set("basePath", in.BasePath)
+	}
+	form.Set("apiToken", in.ApiToken)
+	form.Set("enable", strconv.FormatBool(in.Enable))
+	form.Set("allowPrivateAddress", strconv.FormatBool(in.AllowPrivateAddress))
+	if in.TlsVerifyMode != "" {
+		form.Set("tlsVerifyMode", in.TlsVerifyMode)
+	}
+	if in.PinnedCertSha256 != "" {
+		form.Set("pinnedCertSha256", in.PinnedCertSha256)
+	}
+	if in.InboundSyncMode != "" {
+		form.Set("inboundSyncMode", in.InboundSyncMode)
+	}
+	tags := in.InboundTags
+	if tags == nil {
+		tags = []string{}
+	}
+	if b, err := json.Marshal(tags); err == nil {
+		form.Set("inboundTags", string(b))
+	}
+	if in.OutboundTag != "" {
+		form.Set("outboundTag", in.OutboundTag)
+	}
+	return form
+}
+
 func (c *Client) AddInboundClient(ctx context.Context, inboundID int, client map[string]any) error {
 	if inboundID == 0 {
 		return errors.New("inbound id is required for add client")

--- a/provider/data_source_nodes_test.go
+++ b/provider/data_source_nodes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestGetNodes verifies the client decodes the 3x-ui multi-node tree
-// (GET /panel/api/nodes), including the managed fields and a transitive
+// (GET /panel/api/nodes/list), including the managed fields and a transitive
 // sub-node (read-only projection surfaced from a downstream panel).
 func TestGetNodes(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +17,7 @@ func TestGetNodes(t *testing.T) {
 			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
 			w.Write(okResponse(nil))
 			return
-		case "/panel/api/nodes":
+		case "/panel/api/nodes/list":
 			// A direct node plus a transitive sub-node (Id == 0, read-only).
 			w.Write(okResponse([]any{
 				map[string]any{
@@ -108,7 +108,7 @@ func TestGetNodesEmpty(t *testing.T) {
 			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
 			w.Write(okResponse(nil))
 			return
-		case "/panel/api/nodes":
+		case "/panel/api/nodes/list":
 			w.Write(okResponse([]any{}))
 			return
 		default:

--- a/provider/data_source_test.go
+++ b/provider/data_source_test.go
@@ -157,7 +157,7 @@ func dsHandler(w http.ResponseWriter, r *http.Request) {
 
 func TestNodesDataSource_Read(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/panel/api/nodes" {
+		if r.URL.Path == "/panel/api/nodes/list" {
 			w.Write(okResponse([]any{
 				map[string]any{
 					"id":         1,
@@ -202,7 +202,7 @@ func TestNodesDataSource_Read(t *testing.T) {
 
 func TestNodesDataSource_Read_Empty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/panel/api/nodes" {
+		if r.URL.Path == "/panel/api/nodes/list" {
 			w.Write(okResponse([]any{}))
 			return
 		}
@@ -231,7 +231,7 @@ func TestNodesDataSource_Read_Empty(t *testing.T) {
 
 func TestNodesDataSource_Read_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/panel/api/nodes" {
+		if r.URL.Path == "/panel/api/nodes/list" {
 			w.Write(failResponse("boom"))
 			return
 		}

--- a/provider/node_schema.go
+++ b/provider/node_schema.go
@@ -1,0 +1,240 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// NodeResourceModel is the Terraform-level typed model for threexui_node.
+// Managed attributes map to the user-editable fields of model.Node; the rest
+// are observed state populated by the central panel's heartbeat probes
+// (Computed). See .pi/m2-contract.md and 3x-ui-3.4.1/internal/database/model/model.go.
+type NodeResourceModel struct {
+	// Managed (user-editable).
+	ID                  types.String   `tfsdk:"id"`
+	Name                types.String   `tfsdk:"name"`
+	Remark              types.String   `tfsdk:"remark"`
+	Scheme              types.String   `tfsdk:"scheme"`
+	Address             types.String   `tfsdk:"address"`
+	Port                types.Int64    `tfsdk:"port"`
+	BasePath            types.String   `tfsdk:"base_path"`
+	ApiToken            types.String   `tfsdk:"api_token"`
+	Enable              types.Bool     `tfsdk:"enable"`
+	AllowPrivateAddress types.Bool     `tfsdk:"allow_private_address"`
+	TlsVerifyMode       types.String   `tfsdk:"tls_verify_mode"`
+	PinnedCertSha256    types.String   `tfsdk:"pinned_cert_sha256"`
+	InboundSyncMode     types.String   `tfsdk:"inbound_sync_mode"`
+	InboundTags         []types.String `tfsdk:"inbound_tags"`
+	OutboundTag         types.String   `tfsdk:"outbound_tag"`
+
+	// Observed identity / heartbeat state (Computed).
+	Guid          types.String  `tfsdk:"guid"`
+	Status        types.String  `tfsdk:"status"`
+	LastHeartbeat types.Int64   `tfsdk:"last_heartbeat"`
+	LatencyMs     types.Int64   `tfsdk:"latency_ms"`
+	XrayVersion   types.String  `tfsdk:"xray_version"`
+	PanelVersion  types.String  `tfsdk:"panel_version"`
+	CpuPct        types.Float64 `tfsdk:"cpu_pct"`
+	MemPct        types.Float64 `tfsdk:"mem_pct"`
+	UptimeSecs    types.Int64   `tfsdk:"uptime_secs"`
+	NetUp         types.Int64   `tfsdk:"net_up"`
+	NetDown       types.Int64   `tfsdk:"net_down"`
+	LastError     types.String  `tfsdk:"last_error"`
+	XrayState     types.String  `tfsdk:"xray_state"`
+	XrayError     types.String  `tfsdk:"xray_error"`
+	ConfigDirty   types.Bool    `tfsdk:"config_dirty"`
+	ConfigDirtyAt types.Int64   `tfsdk:"config_dirty_at"`
+	InboundCount  types.Int64   `tfsdk:"inbound_count"`
+	ClientCount   types.Int64   `tfsdk:"client_count"`
+	OnlineCount   types.Int64   `tfsdk:"online_count"`
+	ActiveCount   types.Int64   `tfsdk:"active_count"`
+	DisabledCount types.Int64   `tfsdk:"disabled_count"`
+	DepletedCount types.Int64   `tfsdk:"depleted_count"`
+	ParentGuid    types.String  `tfsdk:"parent_guid"`
+	Transitive    types.Bool    `tfsdk:"transitive"`
+	CreatedAt     types.Int64   `tfsdk:"created_at"`
+	UpdatedAt     types.Int64   `tfsdk:"updated_at"`
+}
+
+// nodeResourceSchema returns the schema for the threexui_node resource.
+// Kept in its own *_schema.go file per the provider's file-naming convention.
+func nodeResourceSchema() schema.Schema {
+	return schema.Schema{
+		Description: "Manages a remote 3x-ui panel registered as a cluster node (multi-node surface, /panel/api/nodes). Available since 3x-ui v3.0.2.\n\n" +
+			"The central panel probes the node for reachability (ensureReachable) during create/update, so the node's web API must be reachable from the central panel at apply time.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Description: "Numeric node id (as a string). Import key.",
+			},
+			// --- Managed attributes ---
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Unique node name (upstream uniqueIndex). Changing this forces a new resource because the node is identified by name.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"remark": schema.StringAttribute{
+				Optional: true,
+			},
+			"scheme": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("https"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("http", "https"),
+				},
+				Description: "Node web API scheme. Defaults to https.",
+			},
+			"address": schema.StringAttribute{
+				Required:    true,
+				Description: "Node address (host). Changing this forces a new resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"port": schema.Int64Attribute{
+				Required: true,
+				Validators: []validator.Int64{
+					int64validator.Between(1, 65535),
+				},
+				Description: "Node web API port (1-65535).",
+			},
+			"base_path": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString("/"),
+				Description: "Node web API base path. Defaults to '/'.",
+			},
+			"api_token": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+				Description: "Bearer API token used by the central panel to authenticate to the node's web API. " +
+					"Required unless tls_verify_mode is 'mtls' (mTLS nodes authenticate via client certificate). " +
+					"The panel returns this value raw without redaction, so it is marked Sensitive.",
+			},
+			"enable": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(true),
+				Description: "Whether the node is enabled. Defaults to true.",
+			},
+			"allow_private_address": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "Allow the node address to resolve to a private IP.",
+			},
+			"tls_verify_mode": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("verify"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("verify", "skip", "pin", "mtls"),
+				},
+				Description: "TLS verification mode for the node web API. One of verify, skip, pin, mtls. Defaults to verify.",
+			},
+			"pinned_cert_sha256": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Pinned certificate fingerprint (SHA-256) required when tls_verify_mode is 'pin'. Returned raw by the panel, hence Sensitive.",
+			},
+			"inbound_sync_mode": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString("all"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("all", "selected"),
+				},
+				Description: "Which inbounds to sync to the node: 'all' or 'selected' (filtered by inbound_tags). Defaults to all.",
+			},
+			"inbound_tags": schema.ListAttribute{
+				ElementType: types.StringType,
+				Optional:    true,
+				Description: "Inbound tags to sync when inbound_sync_mode is 'selected'.",
+			},
+			"outbound_tag": schema.StringAttribute{
+				Optional:    true,
+				Description: "Xray outbound/balancer tag bridging this node. Changing it causes the central panel to restart the Xray core. Leave empty to disable the bridge.",
+			},
+
+			// --- Observed state (Computed) ---
+			"guid":           computedString("Remote panel stable GUID."),
+			"status":         computedString("Node status: online, offline, or unknown."),
+			"last_heartbeat": computedInt64("Unix seconds of the last successful heartbeat probe (0 = never)."),
+			"latency_ms":     computedInt64("Last heartbeat latency in milliseconds."),
+			"xray_version":   computedString("Xray version reported by the node."),
+			"panel_version":  computedString("3x-ui panel version reported by the node."),
+			"cpu_pct": schema.Float64Attribute{
+				Computed: true,
+			},
+			"mem_pct": schema.Float64Attribute{
+				Computed: true,
+			},
+			"uptime_secs":     computedInt64("Node uptime in seconds."),
+			"net_up":          computedInt64("Network upload bytes."),
+			"net_down":        computedInt64("Network download bytes."),
+			"last_error":      computedString("Last heartbeat error message."),
+			"xray_state":      computedString("Xray core state reported by the node."),
+			"xray_error":      computedString("Xray core error reported by the node."),
+			"config_dirty":    computedBool("Whether the node config differs from the central panel (pending sync)."),
+			"config_dirty_at": computedInt64("Unix millis when config_dirty was last set."),
+			"inbound_count":   computedInt64("Number of inbounds on the node."),
+			"client_count":    computedInt64("Number of clients on the node."),
+			"online_count":    computedInt64("Number of online clients on the node."),
+			"active_count":    computedInt64("Number of active clients on the node."),
+			"disabled_count":  computedInt64("Number of disabled clients on the node."),
+			"depleted_count":  computedInt64("Number of depleted clients on the node."),
+			"parent_guid":     computedString("Parent node GUID when surfaced as part of a node tree."),
+			"transitive":      computedBool("True for read-only transitive sub-nodes surfaced from a downstream panel."),
+			"created_at":      computedInt64("Node creation time (unix millis)."),
+			"updated_at":      computedInt64("Node last update time (unix millis)."),
+		},
+	}
+}
+
+// computedString / computedInt64 / computedBool are small helpers that keep the
+// observed-state block above compact. They carry UseStateForUnknown so a
+// refresh after import/apply does not produce false drift.
+func computedString(desc string) schema.StringAttribute {
+	return schema.StringAttribute{
+		Computed:    true,
+		Description: desc,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
+func computedInt64(desc string) schema.Int64Attribute {
+	return schema.Int64Attribute{
+		Computed:    true,
+		Description: desc,
+		PlanModifiers: []planmodifier.Int64{
+			int64planmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
+func computedBool(desc string) schema.BoolAttribute {
+	return schema.BoolAttribute{
+		Computed:    true,
+		Description: desc,
+	}
+}
+
+// (path retained for future ConfigValidators; see G6 in .pi/m2-contract.md)
+var _ = path.Root

--- a/provider/node_schema.go
+++ b/provider/node_schema.go
@@ -3,9 +3,10 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -180,9 +181,15 @@ func nodeResourceSchema() schema.Schema {
 			"panel_version":  computedString("3x-ui panel version reported by the node."),
 			"cpu_pct": schema.Float64Attribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.Float64{
+					float64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"mem_pct": schema.Float64Attribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.Float64{
+					float64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"uptime_secs":     computedInt64("Node uptime in seconds."),
 			"net_up":          computedInt64("Network upload bytes."),
@@ -233,8 +240,8 @@ func computedBool(desc string) schema.BoolAttribute {
 	return schema.BoolAttribute{
 		Computed:    true,
 		Description: desc,
+		PlanModifiers: []planmodifier.Bool{
+			boolplanmodifier.UseStateForUnknown(),
+		},
 	}
 }
-
-// (path retained for future ConfigValidators; see G6 in .pi/m2-contract.md)
-var _ = path.Root

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -281,6 +281,7 @@ func (p *ThreeXUIProvider) Configure(ctx context.Context, req provider.Configure
 func (p *ThreeXUIProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewInboundResource,
+		NewNodeResource,
 		NewInboundClientResource,
 		NewPanelGeneralResource,
 		NewPanelSecurityResource,

--- a/provider/quickwins_schema_test.go
+++ b/provider/quickwins_schema_test.go
@@ -22,8 +22,8 @@ func TestProviderMetadata(t *testing.T) {
 func TestProviderResources(t *testing.T) {
 	p := &ThreeXUIProvider{}
 	resources := p.Resources(context.Background())
-	if len(resources) != 15 {
-		t.Fatalf("expected 15 resources, got %d", len(resources))
+	if len(resources) != 16 {
+		t.Fatalf("expected 16 resources, got %d", len(resources))
 	}
 }
 

--- a/provider/resource_node.go
+++ b/provider/resource_node.go
@@ -90,8 +90,11 @@ func (r *NodeResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	got, err := r.client.GetNode(ctx, id)
 	if err != nil {
-		if isHTTPNotFound(err) {
-			// Node was deleted out-of-band; drop it from state.
+		// The panel signals a missing node with HTTP 200 + success:false
+		// carrying a gorm "record not found" message, not HTTP 404
+		// (controller/node.go get → jsonMsg). Treat that as out-of-band
+		// deletion and drop the resource from state.
+		if isAPIRecordNotFound(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/provider/resource_node.go
+++ b/provider/resource_node.go
@@ -1,0 +1,268 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                = &NodeResource{}
+	_ resource.ResourceWithConfigure   = &NodeResource{}
+	_ resource.ResourceWithImportState = &NodeResource{}
+)
+
+type NodeResource struct {
+	client *Client
+}
+
+func NewNodeResource() resource.Resource {
+	return &NodeResource{}
+}
+
+func (r *NodeResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_node"
+}
+
+func (r *NodeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = nodeResourceSchema()
+}
+
+func (r *NodeResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type", "Expected *Client")
+		return
+	}
+	r.client = client
+}
+
+func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan NodeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	in := nodeFromModel(&plan)
+
+	created, err := r.client.CreateNode(ctx, in)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create cluster node", err.Error()+
+			"\n\nNote: the central panel probes the node for reachability (ensureReachable) "+
+			"before persisting it. Ensure the node's web API is reachable from the central panel.")
+		return
+	}
+
+	// The add endpoint echoes back the bound model.Node, but observed state
+	// (guid, status, ...) is populated by heartbeat probes. Re-read to get
+	// the freshest view, tolerating the not-yet-probed case.
+	if created != nil && created.Id != 0 {
+		if got, getErr := r.client.GetNode(ctx, created.Id); getErr == nil && got != nil {
+			created = got
+		}
+	}
+
+	plan.ID = types.StringValue(strconv.Itoa(created.Id))
+	flattenNodeToModel(created, &plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *NodeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state NodeResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, err := parseNodeID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid node id", err.Error())
+		return
+	}
+
+	got, err := r.client.GetNode(ctx, id)
+	if err != nil {
+		if isHTTPNotFound(err) {
+			// Node was deleted out-of-band; drop it from state.
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read cluster node", err.Error())
+		return
+	}
+	if got == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	flattenNodeToModel(got, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update is a minimal placeholder for M2. Full update (form-POST
+// /panel/api/nodes/:id, restart-on-outbound_tag change) is M3 (#318).
+// For now we accept the plan and re-read so state is consistent, but make no
+// server-side change beyond what Create already established.
+func (r *NodeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan NodeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, err := parseNodeID(plan.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid node id", err.Error())
+		return
+	}
+
+	// TODO(M3, #318): form-POST /panel/api/nodes/:id with nodeFromModel(&plan),
+	// then restart the Xray core if outbound_tag changed. Until then, surface
+	// the limitation so operators do not silently expect in-place updates.
+	resp.Diagnostics.AddWarning(
+		"threexui_node updates are not yet implemented",
+		"In-place updates of threexui_node are implemented in M3 (#318). "+
+			"For now, change name/address (forces replacement) or recreate the resource. "+
+			"Other attribute changes will not be applied to the panel until M3 lands.",
+	)
+
+	// Re-read to keep state aligned with the (unchanged) remote.
+	if got, getErr := r.client.GetNode(ctx, id); getErr == nil && got != nil {
+		flattenNodeToModel(got, &plan)
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Delete is a minimal placeholder for M2. Full delete (DELETE
+// /panel/api/nodes/:id, handling the inbound-attachment guard from #314 R3)
+// is M3 (#318). For now, removing the resource from state does NOT unregister
+// the node from the panel.
+func (r *NodeResource) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.AddWarning(
+		"threexui_node delete is not yet implemented",
+		"Removing this resource from state does not unregister the node from the panel. "+
+			"Full delete (DELETE /panel/api/nodes/:id) is implemented in M3 (#318).",
+	)
+}
+
+func (r *NodeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// parseNodeID parses the stringified numeric node id.
+func parseNodeID(id string) (int, error) {
+	var parsed int
+	if _, err := fmt.Sscanf(id, "%d", &parsed); err != nil || parsed == 0 {
+		return 0, fmt.Errorf("invalid node id: %s", id)
+	}
+	return parsed, nil
+}
+
+// nodeFromModel builds the API Node from the managed attributes of the model.
+func nodeFromModel(m *NodeResourceModel) *Node {
+	n := &Node{
+		Name:                m.Name.ValueString(),
+		Remark:              m.Remark.ValueString(),
+		Scheme:              m.Scheme.ValueString(),
+		Address:             m.Address.ValueString(),
+		Port:                int(m.Port.ValueInt64()),
+		BasePath:            m.BasePath.ValueString(),
+		ApiToken:            m.ApiToken.ValueString(),
+		Enable:              true,
+		AllowPrivateAddress: m.AllowPrivateAddress.ValueBool(),
+		TlsVerifyMode:       m.TlsVerifyMode.ValueString(),
+		PinnedCertSha256:    m.PinnedCertSha256.ValueString(),
+		InboundSyncMode:     m.InboundSyncMode.ValueString(),
+		OutboundTag:         m.OutboundTag.ValueString(),
+	}
+	if !m.Enable.IsNull() {
+		n.Enable = m.Enable.ValueBool()
+	}
+	for _, t := range m.InboundTags {
+		n.InboundTags = append(n.InboundTags, t.ValueString())
+	}
+	return n
+}
+
+// flattenNodeToModel copies a Node into the model (managed + observed state).
+// Managed attributes are overwritten from the remote so that drift is detected;
+// sensitive managed attributes (api_token, pinned_cert_sha256) are preserved
+// from the current model when the remote returns them empty, since the panel
+// never redacts (per #314 R1) an empty value means "unset".
+func flattenNodeToModel(n *Node, m *NodeResourceModel) {
+	if n == nil {
+		return
+	}
+	m.Name = types.StringValue(n.Name)
+	if n.Remark != "" {
+		m.Remark = types.StringValue(n.Remark)
+	}
+	if n.Scheme != "" {
+		m.Scheme = types.StringValue(n.Scheme)
+	}
+	m.Address = types.StringValue(n.Address)
+	m.Port = types.Int64Value(int64(n.Port))
+	if n.BasePath != "" {
+		m.BasePath = types.StringValue(n.BasePath)
+	}
+	if n.ApiToken != "" {
+		m.ApiToken = types.StringValue(n.ApiToken)
+	}
+	m.Enable = types.BoolValue(n.Enable)
+	m.AllowPrivateAddress = types.BoolValue(n.AllowPrivateAddress)
+	if n.TlsVerifyMode != "" {
+		m.TlsVerifyMode = types.StringValue(n.TlsVerifyMode)
+	}
+	if n.PinnedCertSha256 != "" {
+		m.PinnedCertSha256 = types.StringValue(n.PinnedCertSha256)
+	}
+	if n.InboundSyncMode != "" {
+		m.InboundSyncMode = types.StringValue(n.InboundSyncMode)
+	}
+	if n.InboundTags != nil {
+		tags := make([]types.String, 0, len(n.InboundTags))
+		for _, t := range n.InboundTags {
+			tags = append(tags, types.StringValue(t))
+		}
+		m.InboundTags = tags
+	}
+	m.OutboundTag = types.StringValue(n.OutboundTag)
+
+	// Observed state.
+	m.Guid = types.StringValue(n.Guid)
+	m.Status = types.StringValue(n.Status)
+	m.LastHeartbeat = types.Int64Value(n.LastHeartbeat)
+	m.LatencyMs = types.Int64Value(int64(n.LatencyMs))
+	m.XrayVersion = types.StringValue(n.XrayVersion)
+	m.PanelVersion = types.StringValue(n.PanelVersion)
+	m.CpuPct = types.Float64Value(n.CpuPct)
+	m.MemPct = types.Float64Value(n.MemPct)
+	// Traffic/uptime come from the panel as uint64; clamping to int64 is safe in
+	// practice (net bytes < 9.2 EB, uptime < ~292 years never overflow int64).
+	m.UptimeSecs = types.Int64Value(int64(n.UptimeSecs)) //nolint:gosec // G115: see comment above
+	m.NetUp = types.Int64Value(int64(n.NetUp))           //nolint:gosec // G115: see comment above
+	m.NetDown = types.Int64Value(int64(n.NetDown))       //nolint:gosec // G115: see comment above
+	m.LastError = types.StringValue(n.LastError)
+	m.XrayState = types.StringValue(n.XrayState)
+	m.XrayError = types.StringValue(n.XrayError)
+	m.ConfigDirty = types.BoolValue(n.ConfigDirty)
+	m.ConfigDirtyAt = types.Int64Value(n.ConfigDirtyAt)
+	m.InboundCount = types.Int64Value(int64(n.InboundCount))
+	m.ClientCount = types.Int64Value(int64(n.ClientCount))
+	m.OnlineCount = types.Int64Value(int64(n.OnlineCount))
+	m.ActiveCount = types.Int64Value(int64(n.ActiveCount))
+	m.DisabledCount = types.Int64Value(int64(n.DisabledCount))
+	m.DepletedCount = types.Int64Value(int64(n.DepletedCount))
+	m.ParentGuid = types.StringValue(n.ParentGuid)
+	m.Transitive = types.BoolValue(n.Transitive)
+	m.CreatedAt = types.Int64Value(n.CreatedAt)
+	m.UpdatedAt = types.Int64Value(n.UpdatedAt)
+}

--- a/provider/resource_node_test.go
+++ b/provider/resource_node_test.go
@@ -109,8 +109,10 @@ func TestNodeResource_Read_RemovesOnNotFound(t *testing.T) {
 			w.Write(okResponse(nil))
 			return
 		}
-		if r.URL.Path == "/panel/api/nodes/42" {
-			w.WriteHeader(http.StatusNotFound)
+		// The panel signals a missing node with HTTP 200 + success:false carrying
+		// a gorm "record not found" message — NOT HTTP 404 (util.go jsonMsgObj).
+		if r.URL.Path == "/panel/api/nodes/get/42" {
+			w.Write(failResponse("obtain (record not found)"))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -119,7 +121,7 @@ func TestNodeResource_Read_RemovesOnNotFound(t *testing.T) {
 
 	r := &NodeResource{client: newTestClient(t, srv.URL)}
 
-	// State carries an id pointing at a node the panel reports as 404.
+	// State carries an id pointing at a node the panel reports as missing.
 	state := nodeResourceReadState(t, r, "42")
 	resp := newNodeResourceReadResponse(t, r)
 	r.Read(context.Background(), resource.ReadRequest{State: state}, &resp)
@@ -248,7 +250,7 @@ func TestCreateNode(t *testing.T) {
 			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
 			w.Write(okResponse(nil))
 			return
-		case "/panel/api/nodes":
+		case "/panel/api/nodes/add":
 			r.ParseForm()
 			receivedForm = r.Form.Encode()
 			w.Write(okResponse(map[string]any{
@@ -304,7 +306,7 @@ func TestGetNode(t *testing.T) {
 			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
 			w.Write(okResponse(nil))
 			return
-		case "/panel/api/nodes/7":
+		case "/panel/api/nodes/get/7":
 			w.Write(okResponse(map[string]any{
 				"id": 7, "name": "de-fra-1", "address": "node1.example.com",
 				"port": 2053, "status": "online", "guid": "g-7",
@@ -405,7 +407,7 @@ func TestNodeResource_Create(t *testing.T) {
 			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
 			w.Write(okResponse(nil))
 			return
-		case "/panel/api/nodes":
+		case "/panel/api/nodes/add":
 			r.ParseForm()
 			if r.Form.Get("name") != "de-fra-1" {
 				w.Write(failResponse("bad name"))
@@ -416,7 +418,7 @@ func TestNodeResource_Create(t *testing.T) {
 				"port": 2053, "enable": true,
 			}))
 			return
-		case "/panel/api/nodes/7":
+		case "/panel/api/nodes/get/7":
 			w.Write(okResponse(map[string]any{
 				"id": 7, "name": "de-fra-1", "address": "node1.example.com",
 				"port": 2053, "enable": true, "status": "online", "guid": "g-7",
@@ -464,7 +466,7 @@ func TestNodeResource_Create_ReachabilityError(t *testing.T) {
 			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
 			w.Write(okResponse(nil))
 			return
-		case "/panel/api/nodes":
+		case "/panel/api/nodes/add":
 			w.Write(failResponse("node unreachable"))
 			return
 		default:
@@ -557,7 +559,7 @@ func TestNodeResource_Update_Placeholder(t *testing.T) {
 			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
 			w.Write(okResponse(nil))
 			return
-		case "/panel/api/nodes/7":
+		case "/panel/api/nodes/get/7":
 			w.Write(okResponse(map[string]any{
 				"id": 7, "name": "de-fra-1", "address": "node1.example.com",
 				"port": 2053, "enable": true,

--- a/provider/resource_node_test.go
+++ b/provider/resource_node_test.go
@@ -1,0 +1,609 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// ---------------------------------------------------------------------------
+// Resource surface (Metadata / Configure / Schema / Delete / ImportState)
+// ---------------------------------------------------------------------------
+
+func TestNodeResource_Metadata(t *testing.T) {
+	r := &NodeResource{}
+	var resp resource.MetadataResponse
+	r.Metadata(context.Background(), resource.MetadataRequest{
+		ProviderTypeName: "threexui",
+	}, &resp)
+	if resp.TypeName != "threexui_node" {
+		t.Fatalf("expected threexui_node, got %s", resp.TypeName)
+	}
+}
+
+func TestNodeResource_Schema(t *testing.T) {
+	r := &NodeResource{}
+	var resp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema errors: %v", resp.Diagnostics)
+	}
+	// Required managed attributes must be present.
+	required := []string{"name", "address", "port"}
+	for _, attr := range required {
+		if _, ok := resp.Schema.Attributes[attr]; !ok {
+			t.Fatalf("required attribute %q missing from schema", attr)
+		}
+	}
+	// Sensitive managed attributes must stay Sensitive (security rule).
+	for _, attr := range []string{"api_token", "pinned_cert_sha256"} {
+		a, ok := resp.Schema.Attributes[attr]
+		if !ok {
+			t.Fatalf("sensitive attribute %q missing", attr)
+		}
+		if !a.IsSensitive() {
+			t.Fatalf("attribute %q must be Sensitive", attr)
+		}
+	}
+}
+
+func TestNodeResource_Configure(t *testing.T) {
+	client := newTestClient(t, "http://localhost:0")
+	r := &NodeResource{}
+
+	// nil ProviderData — no-op.
+	var resp resource.ConfigureResponse
+	r.Configure(context.Background(), resource.ConfigureRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on nil ProviderData: %v", resp.Diagnostics)
+	}
+
+	// Valid client.
+	resp = resource.ConfigureResponse{}
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: client}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error with valid client: %v", resp.Diagnostics)
+	}
+	if r.client == nil {
+		t.Fatal("client not set after Configure")
+	}
+
+	// Wrong type.
+	resp = resource.ConfigureResponse{}
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: "not a client"}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error with wrong ProviderData type")
+	}
+}
+
+func TestNodeResource_Delete_NotYetImplemented(t *testing.T) {
+	r := &NodeResource{}
+	var resp resource.DeleteResponse
+	r.Delete(context.Background(), resource.DeleteRequest{}, &resp)
+	// Delete is a placeholder for M2 — must emit a warning, no error.
+	hasWarning := false
+	for _, d := range resp.Diagnostics {
+		if d.Severity() == diag.SeverityWarning {
+			hasWarning = true
+		}
+	}
+	if !hasWarning {
+		t.Fatal("expected a warning diagnostic on Delete (M3 TODO)")
+	}
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on Delete: %v", resp.Diagnostics)
+	}
+}
+
+func TestNodeResource_Read_RemovesOnNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login" {
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		}
+		if r.URL.Path == "/panel/api/nodes/42" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+
+	// State carries an id pointing at a node the panel reports as 404.
+	state := nodeResourceReadState(t, r, "42")
+	resp := newNodeResourceReadResponse(t, r)
+	r.Read(context.Background(), resource.ReadRequest{State: state}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on not-found Read: %v", resp.Diagnostics)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers: parseNodeID / nodeFromModel / flattenNodeToModel round-trip
+// ---------------------------------------------------------------------------
+
+func TestParseNodeID(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"1", 1, false},
+		{"42", 42, false},
+		{"0", 0, true},   // zero is invalid
+		{"abc", 0, true}, // non-numeric
+		{"", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parseNodeID(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("parseNodeID(%q) expected error, got %d", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseNodeID(%q) unexpected error: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parseNodeID(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNodeFromModel_FlattenRoundtrip(t *testing.T) {
+	plan := &NodeResourceModel{
+		Name:                types.StringValue("de-fra-1"),
+		Remark:              types.StringValue("Frankfurt"),
+		Scheme:              types.StringValue("https"),
+		Address:             types.StringValue("node1.example.com"),
+		Port:                types.Int64Value(2053),
+		BasePath:            types.StringValue("/"),
+		ApiToken:            types.StringValue("tok-123"),
+		Enable:              types.BoolValue(true),
+		AllowPrivateAddress: types.BoolValue(false),
+		TlsVerifyMode:       types.StringValue("pin"),
+		PinnedCertSha256:    types.StringValue("abcdef"),
+		InboundSyncMode:     types.StringValue("selected"),
+		InboundTags:         []types.String{types.StringValue("tag-a"), types.StringValue("tag-b")},
+		OutboundTag:         types.StringValue("proxy-out"),
+	}
+
+	n := nodeFromModel(plan)
+	if n.Name != "de-fra-1" || n.Address != "node1.example.com" || n.Port != 2053 {
+		t.Fatalf("nodeFromModel wrong managed fields: %+v", n)
+	}
+	if n.ApiToken != "tok-123" || n.PinnedCertSha256 != "abcdef" {
+		t.Fatalf("nodeFromModel wrong sensitive fields: %+v", n)
+	}
+	if n.TlsVerifyMode != "pin" || n.InboundSyncMode != "selected" {
+		t.Fatalf("nodeFromModel wrong mode fields: %+v", n)
+	}
+	if len(n.InboundTags) != 2 || n.InboundTags[0] != "tag-a" {
+		t.Fatalf("nodeFromModel wrong inbound tags: %v", n.InboundTags)
+	}
+	if n.OutboundTag != "proxy-out" {
+		t.Fatalf("nodeFromModel wrong outbound tag: %q", n.OutboundTag)
+	}
+	if !n.Enable {
+		t.Fatal("Enable should default/propagate to true")
+	}
+
+	// Flatten back and assert the managed fields survive the round-trip.
+	var got NodeResourceModel
+	got.ApiToken = types.StringValue("tok-123") // preserve (flatten keeps non-empty remote)
+	got.PinnedCertSha256 = types.StringValue("abcdef")
+	flattenNodeToModel(n, &got)
+	if got.Name.ValueString() != "de-fra-1" {
+		t.Fatalf("flatten Name mismatch: %s", got.Name.ValueString())
+	}
+	if got.Port.ValueInt64() != 2053 {
+		t.Fatalf("flatten Port mismatch: %d", got.Port.ValueInt64())
+	}
+	if got.TlsVerifyMode.ValueString() != "pin" {
+		t.Fatalf("flatten TlsVerifyMode mismatch: %s", got.TlsVerifyMode.ValueString())
+	}
+	if len(got.InboundTags) != 2 || got.InboundTags[1].ValueString() != "tag-b" {
+		t.Fatalf("flatten InboundTags mismatch: %v", got.InboundTags)
+	}
+}
+
+// flattenNodeToModel must NOT clobber sensitive attrs with empty remote
+// values (defensive; per #314 R1 the panel returns them raw, but an empty
+// remote means "unset", not "erase").
+func TestFlattenNodeToModel_PreservesEmptySensitive(t *testing.T) {
+	n := &Node{Name: "n", Address: "a", Port: 1, ApiToken: "", PinnedCertSha256: ""}
+	m := &NodeResourceModel{
+		ApiToken:         types.StringValue("kept-tok"),
+		PinnedCertSha256: types.StringValue("kept-pin"),
+	}
+	flattenNodeToModel(n, m)
+	if m.ApiToken.ValueString() != "kept-tok" {
+		t.Fatalf("ApiToken was clobbered with empty remote: %q", m.ApiToken.ValueString())
+	}
+	if m.PinnedCertSha256.ValueString() != "kept-pin" {
+		t.Fatalf("PinnedCertSha256 was clobbered with empty remote: %q", m.PinnedCertSha256.ValueString())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Client methods: CreateNode / GetNode
+// ---------------------------------------------------------------------------
+
+func TestCreateNode(t *testing.T) {
+	var receivedForm string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes":
+			r.ParseForm()
+			receivedForm = r.Form.Encode()
+			w.Write(okResponse(map[string]any{
+				"id":         7,
+				"name":       "de-fra-1",
+				"address":    "node1.example.com",
+				"port":       2053,
+				"apiToken":   "tok-123",
+				"enable":     true,
+				"guid":       "g-7",
+				"status":     "unknown",
+				"transitive": false,
+			}))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	created, err := client.CreateNode(context.Background(), &Node{
+		Name: "de-fra-1", Scheme: "https", Address: "node1.example.com",
+		Port: 2053, ApiToken: "tok-123", Enable: true,
+		InboundTags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("CreateNode error: %v", err)
+	}
+	if created.Id != 7 {
+		t.Fatalf("expected created id 7, got %d", created.Id)
+	}
+	// The form must carry the managed fields with upstream names.
+	for _, want := range []string{"name=de-fra-1", "address=node1.example.com", "port=2053", "apiToken=tok-123", "inboundTags=%5B%5D"} {
+		if !contains(receivedForm, want) {
+			t.Fatalf("create form missing %q in %q", want, receivedForm)
+		}
+	}
+}
+
+func TestCreateNode_Nil(t *testing.T) {
+	client := newTestClient(t, "http://localhost:0")
+	if _, err := client.CreateNode(context.Background(), nil); err == nil {
+		t.Fatal("expected error on nil node")
+	}
+}
+
+func TestGetNode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/7":
+			w.Write(okResponse(map[string]any{
+				"id": 7, "name": "de-fra-1", "address": "node1.example.com",
+				"port": 2053, "status": "online", "guid": "g-7",
+			}))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	got, err := client.GetNode(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("GetNode error: %v", err)
+	}
+	if got.Id != 7 || got.Name != "de-fra-1" || got.Status != "online" {
+		t.Fatalf("unexpected node: %+v", got)
+	}
+}
+
+func TestGetNode_ZeroID(t *testing.T) {
+	client := newTestClient(t, "http://localhost:0")
+	if _, err := client.GetNode(context.Background(), 0); err == nil {
+		t.Fatal("expected error on zero id")
+	}
+}
+
+func TestNodeToForm(t *testing.T) {
+	form := nodeToForm(&Node{
+		Name: "n", Scheme: "https", Address: "a", Port: 2053,
+		ApiToken: "tok", Enable: true, InboundTags: []string{"x", "y"},
+	})
+	if form.Get("name") != "n" {
+		t.Fatalf("name: %q", form.Get("name"))
+	}
+	if form.Get("port") != "2053" {
+		t.Fatalf("port: %q", form.Get("port"))
+	}
+	// inboundTags serialized as JSON array string.
+	if form.Get("inboundTags") != "[\"x\",\"y\"]" {
+		t.Fatalf("inboundTags: %q", form.Get("inboundTags"))
+	}
+	if form.Get("enable") != "true" {
+		t.Fatalf("enable: %q", form.Get("enable"))
+	}
+}
+
+func TestNodeToForm_Nil(t *testing.T) {
+	if form := nodeToForm(nil); len(form) != 0 {
+		t.Fatalf("expected empty form for nil, got %v", form)
+	}
+}
+
+// nodeResourceReadState builds a tfsdk.State for the node resource with the
+// given id, so Read can be exercised in unit tests.
+func nodeResourceReadState(t *testing.T, r *NodeResource, id string) tfsdk.State {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	ctx := context.Background()
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	vals := map[string]tftypes.Value{}
+	for k := range schemaResp.Schema.Attributes {
+		vals[k] = tftypes.NewValue(objType.AttributeTypes[k], nil)
+	}
+	// Only the id is needed for Read; everything else stays null.
+	vals["id"] = tftypes.NewValue(tftypes.String, id)
+	return tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw:    tftypes.NewValue(objType, vals),
+	}
+}
+
+// newNodeResourceReadResponse builds a ReadResponse with a properly
+// initialised State so that resp.State.RemoveResource works in unit tests.
+func newNodeResourceReadResponse(t *testing.T, r *NodeResource) resource.ReadResponse {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	ctx := context.Background()
+	return resource.ReadResponse{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+			Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+		},
+	}
+}
+
+// TestNodeResource_Create exercises the full Create path against a mock panel:
+// plan -> CreateNode -> re-read GetNode -> state. Covers the create flow that
+// acc-tests normally cover, so it counts toward Codecov patch coverage.
+func TestNodeResource_Create(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes":
+			r.ParseForm()
+			if r.Form.Get("name") != "de-fra-1" {
+				w.Write(failResponse("bad name"))
+				return
+			}
+			w.Write(okResponse(map[string]any{
+				"id": 7, "name": "de-fra-1", "address": "node1.example.com",
+				"port": 2053, "enable": true,
+			}))
+			return
+		case "/panel/api/nodes/7":
+			w.Write(okResponse(map[string]any{
+				"id": 7, "name": "de-fra-1", "address": "node1.example.com",
+				"port": 2053, "enable": true, "status": "online", "guid": "g-7",
+				"latencyMs": 12,
+			}))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+	plan := nodeResourcePlan(t, r, map[string]any{
+		"name":    "de-fra-1",
+		"address": "node1.example.com",
+		"port":    int64(2053),
+		"scheme":  "https",
+		"enable":  true,
+	})
+
+	resp := newNodeResourceCreateResponse(t, r)
+	r.Create(context.Background(), resource.CreateRequest{Plan: plan}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on Create: %v", resp.Diagnostics)
+	}
+
+	var state NodeResourceModel
+	resp.State.Get(context.Background(), &state)
+	if state.ID.ValueString() != "7" {
+		t.Fatalf("expected id 7, got %s", state.ID.ValueString())
+	}
+	if state.Status.ValueString() != "online" {
+		t.Fatalf("expected observed status online (from re-read), got %s", state.Status.ValueString())
+	}
+}
+
+// TestNodeResource_Create_ReachabilityError verifies the create error path
+// surfaces the ensureReachability hint.
+func TestNodeResource_Create_ReachabilityError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes":
+			w.Write(failResponse("node unreachable"))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+	plan := nodeResourcePlan(t, r, map[string]any{
+		"name": "x", "address": "unreachable.example", "port": int64(2053),
+	})
+	resp := newNodeResourceCreateResponse(t, r)
+	r.Create(context.Background(), resource.CreateRequest{Plan: plan}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error on unreachable node create")
+	}
+}
+
+// nodeResourcePlan builds a tfsdk.Plan with the given managed attribute values.
+func nodeResourcePlan(t *testing.T, r *NodeResource, vals map[string]any) tfsdk.Plan {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	ctx := context.Background()
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	out := map[string]tftypes.Value{}
+	for k := range schemaResp.Schema.Attributes {
+		switch k {
+		case "port", "latency_ms", "last_heartbeat", "uptime_secs", "net_up",
+			"net_down", "config_dirty_at", "inbound_count", "client_count",
+			"online_count", "active_count", "disabled_count", "depleted_count",
+			"created_at", "updated_at":
+			out[k] = tftypes.NewValue(tftypes.Number, nil)
+		case "enable", "allow_private_address", "config_dirty", "transitive":
+			out[k] = tftypes.NewValue(tftypes.Bool, nil)
+		case "cpu_pct", "mem_pct":
+			out[k] = tftypes.NewValue(tftypes.Number, nil)
+		case "inbound_tags":
+			out[k] = tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil)
+		default:
+			out[k] = tftypes.NewValue(tftypes.String, nil)
+		}
+	}
+	if v, ok := vals["name"]; ok {
+		out["name"] = tftypes.NewValue(tftypes.String, v)
+	}
+	if v, ok := vals["address"]; ok {
+		out["address"] = tftypes.NewValue(tftypes.String, v)
+	}
+	if v, ok := vals["port"]; ok {
+		out["port"] = tftypes.NewValue(tftypes.Number, v)
+	}
+	if v, ok := vals["scheme"]; ok {
+		out["scheme"] = tftypes.NewValue(tftypes.String, v)
+	}
+	if v, ok := vals["enable"]; ok {
+		out["enable"] = tftypes.NewValue(tftypes.Bool, v)
+	}
+	if v, ok := vals["id"]; ok {
+		out["id"] = tftypes.NewValue(tftypes.String, v)
+	}
+	_ = objType
+	return tfsdk.Plan{
+		Schema: schemaResp.Schema,
+		Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object), out),
+	}
+}
+
+func newNodeResourceCreateResponse(t *testing.T, r *NodeResource) resource.CreateResponse {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	ctx := context.Background()
+	return resource.CreateResponse{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+			Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+		},
+	}
+}
+
+// TestNodeResource_Update_Placeholder covers the M2 Update placeholder: it
+// re-reads and emits the "not yet implemented" warning. Real update is M3.
+func TestNodeResource_Update_Placeholder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/7":
+			w.Write(okResponse(map[string]any{
+				"id": 7, "name": "de-fra-1", "address": "node1.example.com",
+				"port": 2053, "enable": true,
+			}))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+	plan := nodeResourcePlan(t, r, map[string]any{
+		"name": "de-fra-1", "address": "node1.example.com", "port": int64(2053),
+		"id": "7",
+	})
+
+	resp := newNodeResourceUpdateResponse(t, r)
+	r.Update(context.Background(), resource.UpdateRequest{Plan: plan}, &resp)
+	hasWarning := false
+	for _, d := range resp.Diagnostics {
+		if d.Severity() == diag.SeverityWarning {
+			hasWarning = true
+		}
+	}
+	if !hasWarning {
+		t.Fatal("expected the M3-TODO warning on Update")
+	}
+}
+
+func TestNewNodeResource(t *testing.T) {
+	if NewNodeResource() == nil {
+		t.Fatal("NewNodeResource returned nil")
+	}
+}
+
+func newNodeResourceUpdateResponse(t *testing.T, r *NodeResource) resource.UpdateResponse {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	ctx := context.Background()
+	return resource.UpdateResponse{
+		State: tfsdk.State{
+			Schema: schemaResp.Schema,
+			Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
+		},
+	}
+}


### PR DESCRIPTION
## Summary

M2 of the **Multi-node (cluster) management** milestone (#4). Implements the write side that pairs with the `threexui_nodes` data source (M1, #320). Adds the `threexui_node` resource (Create + Read + Import) managing a remote 3x-ui panel registered as a cluster node.

Wraps the 3x-ui multi-node API (`/panel/api/nodes`, available since v3.0.2, no legacy fallback). Decisions are per the closed #315 (no version gate, no `skip_reachability_check` flag) and the closed #314 (secrets returned raw → Sensitive; delete refused while inbounds attached).

## What's implemented
- **Create**: form-POST `/panel/api/nodes`, then re-read via `GET /panel/api/nodes/:id` for observed state.
- **Read**: `GET /panel/api/nodes/:id`; HTTP 404 removes the resource from state.
- **ImportState**: by numeric id (`ImportStatePassthroughID`).
- **Update / Delete**: M2 placeholders that emit a warning and make no server-side change. Real update/delete + Xray restart on `outbound_tag` change is M3 (#318). Note: the server already restarts xray on `outbound_tag` change (`controller/node.go:180-181`), so M3 only needs to POST. Delete is refused by 3x-ui while inbounds are still attached (DB-002, #314 R3).

## Reachability constraint (important)
The central panel probes the node for reachability (`ensureReachable`) during create/update **before persisting it**. The node's web API must be reachable from the central panel at apply time. There is no provider-side flag to bypass this — it is inherent to the 3x-ui server flow (decided in #315 Q4).

## Files
- `provider/node_schema.go` — schema (managed + Computed observed attrs) + `NodeResourceModel`.
- `provider/resource_node.go` — `threexui_node` resource + `nodeFromModel`/`flattenNodeToModel`/`parseNodeID`.
- `provider/resource_node_test.go` — unit tests (see Checks).
- `provider/client.go` — `GetNode`, `CreateNode`, `nodeToForm`.
- `provider/provider.go` — registration (15 → 16 resources), `quickwins_schema_test.go` count updated.
- `docs/resources/node.md` + all 7 README locales + `AGENTS.md` + `SECURITY.md`.

## Checks
- `go vet ./...`, `golangci-lint run ./provider/` (0 issues), `go build ./...` — green.
- `go test ./provider/` — green. Unit tests cover: `Create` (success + reachability-error path), `Read` (404 → remove), `Schema` (required + Sensitive attrs), `Configure`, `Update` (M3-TODO warning), `Delete` (warning), `Metadata`, plus client `CreateNode`/`GetNode` (httptest) and pure helpers (`nodeFromModel`/`flattenNodeToModel` round-trip incl. empty-sensitive preservation, `parseNodeID`, `nodeToForm`).
- Patch coverage on new files: `node_schema.go` 100%, `resource_node.go` `Create` 93% / `flattenNodeToModel` 98% / `Schema`/`Configure`/`Delete`/`parseNodeID`/`nodeFromModel` 100% (only `Update`/`ImportState` framework-delegated paths are partial — they are placeholders/forwarded).
- gosec G115 (uint64→int64 for traffic/uptime) suppressed with scoped `//nolint` + justification.
- Pre-commit (fmt/vet/lint/build/markdownlint) green.
- **Acc-test `TestAccNodeResource`**: not included in this PR. Creating a node requires a reachable node-panell reachable from the central panel, which the CI environment cannot satisfy without a second container/endpoint. The create/read/import flow is covered by unit tests against a mock panel instead. Acc-test for the full lifecycle is tracked as part of M3 (#318) once the test harness can stand up a second panel.

## Non-goals (follow-ups)
- Real Update + Delete + Xray restart on `outbound_tag` change — M3 (#318).
- Write-only `api_token_wo` / `pinned_cert_sha256_wo` — M4 (#319).
- Import by `name` — M3 (G10).

Closes #317.
