### PR TITLE
feat(node): real Update + Delete for threexui_node (M3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,23 +172,25 @@ above for the `password` / `password_wo` lifecycle.
 
 `threexui_node` — manages a remote 3x-ui panel registered as a cluster node
 (multi-node surface, `/panel/api/nodes/*`; available since v3.0.2, no legacy
-fallback). Create does a form-POST `/panel/api/nodes/add`; the **central panel
-probes the node for reachability (`ensureReachable`) before persisting it**, so
-the node's web API must be reachable from the central panel at apply time —
-there is no provider-side flag to bypass this (decided in #315). Read does
-`GET /panel/api/nodes/get/:id` and treats a missing node (the panel signals
-this as HTTP 200 + `success:false` with a gorm "record not found" message,
-NOT HTTP 404 — see `util.go jsonMsgObj`) as remove-from-state. Import is
-by numeric id (`ImportStatePassthroughID`). **Update and Delete are M2
-placeholders** (warning, no server change); real update (form-POST
-`/panel/api/nodes/update/:id` + Xray restart on `outbound_tag` change — the server
-already restarts on `outbound_tag` change per `controller/node.go:180-181`, so
-the provider only needs to POST) and real delete (DELETE, which 3x-ui refuses
-when inbounds are still attached — DB-002, #314 R3) are M3 (#318). `api_token`
-and `pinned_cert_sha256` are `Sensitive` (the panel returns them raw, no
-redaction — #314 R1); write-only `_wo` variants are M4 (#319). Schema lives in
-`node_schema.go`; the typed `Node` model is shared with the `threexui_nodes`
-data source (`types.go`).
+fallback). Routes are gin subpaths: list `GET /list`, read `GET /get/:id`, create
+`POST /add`, update `POST /update/:id`, delete `POST /del/:id` (POST, not DELETE).
+Create does a form-POST `/add`, then re-reads `/get/:id` for observed state. The
+**central panel probes the node for reachability (`ensureReachable`) before
+persisting it**, so the node's web API must be reachable from the central panel
+at apply time — there is no provider-side flag to bypass this (decided in #315).
+Read does `GET /get/:id` and treats a missing node (the panel signals this as
+HTTP 200 + `success:false` with a gorm "record not found" message, NOT HTTP 404
+— see `util.go jsonMsgObj`; handled via `isAPIRecordNotFound`) as remove-from-
+state. Update form-POSTs `/update/:id` then re-reads; the **3x-ui server
+restarts the Xray core itself** when `outbound_tag` changes
+(`controller/node.go:180-181`), so the provider does NOT call
+`RestartXrayService` (unlike `threexui_inbound`'s `restart_xray = true`). Delete
+POSTs `/del/:id`; 3x-ui refuses to delete a node that still owns inbounds
+(DB-002, #314 R3) — surfaced as a clear error so the operator detaches the
+inbounds first. Import is by numeric id (`ImportStatePassthroughID`). `api_token`
+and `pinned_cert_sha256` are `Sensitive` (panel returns them raw, no redaction —
+issue #314 R1); write-only `_wo` variants are M4 (issue #319). Schema lives in `node_schema.go`;
+the typed `Node` model is shared with the `threexui_nodes` data source (`types.go`).
 
 ### HTTP client (`client.go`)
 

--- a/README.ar_EG.md
+++ b/README.ar_EG.md
@@ -145,7 +145,7 @@ resource "threexui_inbound_client" "client_a" {
 | --- | --- |
 | `threexui_inbound` | inbound (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria؛ socks/dokodemo-door legacy قبل 3.2) |
 | `threexui_inbound_client` | عميل داخل inbound |
-| `threexui_node` | عقدة الكتلة / تسجيل multi-node (Create/Read/Import) |
+| `threexui_node` | عقدة الكتلة / تسجيل multi-node |
 | `threexui_panel_general` | إعدادات اللوحة العامة |
 | `threexui_panel_security` | إعدادات الأمان (2FA) |
 | `threexui_panel_user` | بيانات اعتماد المسؤول |

--- a/README.es_ES.md
+++ b/README.es_ES.md
@@ -139,7 +139,7 @@ La documentación completa está en el [Terraform Registry](https://registry.ter
 | --- | --- |
 | `threexui_inbound` | Inbound (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; socks/dokodemo-door legacy antes de 3.2) |
 | `threexui_inbound_client` | Cliente dentro de un inbound |
-| `threexui_node` | Nodo del clúster / registro multi-node (Create/Read/Import) |
+| `threexui_node` | Nodo del clúster / registro multi-node |
 | `threexui_panel_general` | Ajustes generales del panel |
 | `threexui_panel_security` | Ajustes de seguridad (2FA) |
 | `threexui_panel_user` | Credenciales de administrador |

--- a/README.fa_IR.md
+++ b/README.fa_IR.md
@@ -145,7 +145,7 @@ resource "threexui_inbound_client" "client_a" {
 | --- | --- |
 | `threexui_inbound` | اینباند (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria؛ socks/dokodemo-door در نسخه‌های قبل از 3.2 به‌صورت legacy) |
 | `threexui_inbound_client` | کلاینت داخل اینباند |
-| `threexui_node` | گره کلاستر / ثبت multi-node (Create/Read/Import) |
+| `threexui_node` | گره کلاستر / ثبت multi-node |
 | `threexui_panel_general` | تنظیمات عمومی پنل |
 | `threexui_panel_security` | تنظیمات امنیت (2FA) |
 | `threexui_panel_user` | اعتبارنامه‌های ادمین |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Full documentation is available on the [Terraform Registry](https://registry.ter
 | --- | --- |
 | `threexui_inbound` | Inbound proxy (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; legacy socks/dokodemo-door before 3.2) |
 | `threexui_inbound_client` | Client within an inbound |
-| `threexui_node` | Cluster node / multi-node registration (Create/Read/Import) |
+| `threexui_node` | Cluster node / multi-node registration |
 | `threexui_panel_general` | General panel settings |
 | `threexui_panel_security` | Security settings (2FA) |
 | `threexui_panel_user` | Admin credentials |

--- a/README.ru_RU.md
+++ b/README.ru_RU.md
@@ -139,7 +139,7 @@ resource "threexui_inbound_client" "client_a" {
 | --- | --- |
 | `threexui_inbound` | Инбаунд (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; legacy socks/dokodemo-door до 3.2) |
 | `threexui_inbound_client` | Клиент внутри инбаунда |
-| `threexui_node` | Узел кластера / регистрация multi-node (Create/Read/Import) |
+| `threexui_node` | Узел кластера / регистрация multi-node |
 | `threexui_panel_general` | Общие настройки панели |
 | `threexui_panel_security` | Безопасность (2FA) |
 | `threexui_panel_user` | Учётные данные администратора |

--- a/README.tr_TR.md
+++ b/README.tr_TR.md
@@ -139,7 +139,7 @@ Tam belgeler [Terraform Registry](https://registry.terraform.io/providers/batono
 | --- | --- |
 | `threexui_inbound` | Inbound proxy (vless, vmess, trojan, shadowsocks, http, mixed, wireguard, tunnel, hysteria; 3.2 öncesi legacy socks/dokodemo-door) |
 | `threexui_inbound_client` | Bir inbound içindeki istemci |
-| `threexui_node` | Küme düğümü / multi-node kaydı (Create/Read/Import) |
+| `threexui_node` | Küme düğümü / multi-node kaydı |
 | `threexui_panel_general` | Genel panel ayarları |
 | `threexui_panel_security` | Güvenlik ayarları (2FA) |
 | `threexui_panel_user` | Yönetici kimlik bilgileri |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -139,7 +139,7 @@ resource "threexui_inbound_client" "client_a" {
 | --- | --- |
 | `threexui_inbound` | inbound 代理(vless、vmess、trojan、shadowsocks、http、mixed、wireguard、tunnel、hysteria；3.2 之前兼容 legacy socks/dokodemo-door) |
 | `threexui_inbound_client` | inbound 内的客户端 |
-| `threexui_node` | 集群节点 / multi-node 注册（Create/Read/Import） |
+| `threexui_node` | 集群节点 / multi-node 注册 |
 | `threexui_panel_general` | 面板通用设置 |
 | `threexui_panel_security` | 安全设置(2FA) |
 | `threexui_panel_user` | 管理员凭据 |

--- a/docs/resources/node.md
+++ b/docs/resources/node.md
@@ -11,7 +11,7 @@ Manages a remote 3x-ui panel registered as a cluster node on the central panel. 
 
 > **Reachability constraint:** The central panel probes the node for reachability (`ensureReachable`) during create/update before persisting it. The node's web API **must be reachable from the central panel at apply time**, otherwise the create/update fails. There is no way to bypass this from the provider — it is inherent to the 3x-ui server flow.
 >
-> **Scope (M2):** This resource implements **Create + Read + Import**. **In-place Update and Delete are placeholders** that emit a warning and do not change the node on the panel; they are implemented in M3 (#318). To change a node today, change `name`/`address` (forces replacement) or recreate the resource. Write-only secrets (`api_token_wo`) are M4 (#319).
+> **Xray restart on `outbound_tag` change:** changing `outbound_tag` causes the 3x-ui server to restart the Xray core itself (`controller/node.go` update handler). The provider does not issue a separate restart — it relies on the server-side behaviour.
 
 ## Example Usage
 
@@ -73,6 +73,10 @@ In addition to the arguments above, the following observed-state attributes are 
 - `parent_guid` (String) / `transitive` (Bool) - Node-tree attribution (read-only transitive sub-nodes have `transitive = true`).
 - `created_at` / `updated_at` (Number) - Unix millis.
 
+## Delete behaviour
+
+`terraform destroy` unregisters the node from the panel (`POST /panel/api/nodes/del/:id`). 3x-ui **refuses** to delete a node that still owns inbounds (DB-002): if any inbound references this node, the delete fails with an error mentioning the attached inbounds. Detach or delete those inbounds first, then re-run `terraform destroy`. If the node was already removed out-of-band, delete succeeds (treated as already gone).
+
 ## Import
 
 Import is supported by numeric id:
@@ -80,3 +84,5 @@ Import is supported by numeric id:
 ```bash
 terraform import threexui_node.NAME <id>
 ```
+
+> **Scope note:** Write-only secret attributes (`api_token_wo`, `pinned_cert_sha256_wo`) are M4 (#319). Until then, `api_token`/`pinned_cert_sha256` are plain `Sensitive`.

--- a/provider/client.go
+++ b/provider/client.go
@@ -610,6 +610,36 @@ func (c *Client) CreateNode(ctx context.Context, n *Node) (*Node, error) {
 	return &out, nil
 }
 
+// UpdateNode updates a cluster node's managed fields (POST
+// /panel/api/nodes/update/:id). The 3x-ui controller restarts the Xray core
+// itself when outbound_tag changes (controller/node.go:180-181) and runs
+// ensureReachable, so the provider does NOT need to call RestartXrayService.
+// The update handler returns only a status message (no object), so callers
+// must re-read via GetNode to refresh observed state.
+func (c *Client) UpdateNode(ctx context.Context, id int, n *Node) error {
+	if n == nil {
+		return errors.New("node is nil")
+	}
+	if id == 0 {
+		return errors.New("node id is required for update")
+	}
+	form := nodeToForm(n)
+	return c.doForm(ctx, http.MethodPost, fmt.Sprintf("panel/api/nodes/update/%d", id), form, nil)
+}
+
+// DeleteNode unregisters a cluster node from the central panel (POST
+// /panel/api/nodes/del/:id — gin uses POST, not DELETE). 3x-ui refuses to
+// delete a node that still owns inbounds (DB-002); the panel surfaces that as
+// HTTP 200 + success:false with an "inbound(s) still attached" message, which
+// doForm surfaces as a request-failed error. Callers should surface that to
+// the operator so they detach/delete the inbounds first.
+func (c *Client) DeleteNode(ctx context.Context, id int) error {
+	if id == 0 {
+		return errors.New("node id is required for delete")
+	}
+	return c.doForm(ctx, http.MethodPost, fmt.Sprintf("panel/api/nodes/del/%d", id), url.Values{}, nil)
+}
+
 // nodeToForm builds the application/x-www-form-urlencoded body for node
 // create/update, mirroring the form tags on model.Node in 3x-ui. inboundTags
 // is serialized to a JSON string (gorm json serializer on the upstream side).

--- a/provider/resource_node.go
+++ b/provider/resource_node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -110,10 +111,10 @@ func (r *NodeResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-// Update is a minimal placeholder for M2. Full update (form-POST
-// /panel/api/nodes/:id, restart-on-outbound_tag change) is M3 (#318).
-// For now we accept the plan and re-read so state is consistent, but make no
-// server-side change beyond what Create already established.
+// Update applies in-place changes to a cluster node via form-POST
+// /panel/api/nodes/update/:id. The 3x-ui controller restarts the Xray core
+// itself when outbound_tag changes (controller/node.go:180-181) and runs
+// ensureReachable, so this method does NOT call RestartXrayService.
 func (r *NodeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan NodeResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -127,33 +128,61 @@ func (r *NodeResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	// TODO(M3, #318): form-POST /panel/api/nodes/:id with nodeFromModel(&plan),
-	// then restart the Xray core if outbound_tag changed. Until then, surface
-	// the limitation so operators do not silently expect in-place updates.
-	resp.Diagnostics.AddWarning(
-		"threexui_node updates are not yet implemented",
-		"In-place updates of threexui_node are implemented in M3 (#318). "+
-			"For now, change name/address (forces replacement) or recreate the resource. "+
-			"Other attribute changes will not be applied to the panel until M3 lands.",
-	)
+	if err := r.client.UpdateNode(ctx, id, nodeFromModel(&plan)); err != nil {
+		hint := ""
+		if strings.Contains(strings.ToLower(err.Error()), "unreachable") {
+			hint = "\n\nNote: the central panel probes the node for reachability (ensureReachable) during update. Ensure the node's web API is reachable from the central panel."
+		}
+		resp.Diagnostics.AddError("Failed to update cluster node", err.Error()+hint)
+		return
+	}
 
-	// Re-read to keep state aligned with the (unchanged) remote.
-	if got, getErr := r.client.GetNode(ctx, id); getErr == nil && got != nil {
+	// The update handler returns only a status message (no object), so re-read
+	// to refresh observed state and detect drift.
+	got, getErr := r.client.GetNode(ctx, id)
+	if getErr != nil {
+		if isAPIRecordNotFound(getErr) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddWarning("Failed to re-read node after update", getErr.Error())
+	} else if got != nil {
 		flattenNodeToModel(got, &plan)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-// Delete is a minimal placeholder for M2. Full delete (DELETE
-// /panel/api/nodes/:id, handling the inbound-attachment guard from #314 R3)
-// is M3 (#318). For now, removing the resource from state does NOT unregister
-// the node from the panel.
-func (r *NodeResource) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddWarning(
-		"threexui_node delete is not yet implemented",
-		"Removing this resource from state does not unregister the node from the panel. "+
-			"Full delete (DELETE /panel/api/nodes/:id) is implemented in M3 (#318).",
-	)
+// Delete unregisters a cluster node from the central panel (POST
+// /panel/api/nodes/del/:id). 3x-ui refuses to delete a node that still owns
+// inbounds (DB-002, #314 R3); in that case the operator must detach/delete
+// the inbounds first. Other transient failures return an error; on success
+// the resource is removed from state.
+func (r *NodeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state NodeResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id, err := parseNodeID(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid node id", err.Error())
+		return
+	}
+
+	if err := r.client.DeleteNode(ctx, id); err != nil {
+		if isAPIRecordNotFound(err) {
+			// Already gone out-of-band; treat as deleted.
+			return
+		}
+		msg := err.Error()
+		if strings.Contains(strings.ToLower(msg), "inbound") || strings.Contains(strings.ToLower(msg), "attached") {
+			msg += "\n\n3x-ui refuses to delete a node that still owns inbounds (DB-002). " +
+				"Detach or delete the inbounds referencing this node first, then re-run terraform destroy."
+		}
+		resp.Diagnostics.AddError("Failed to delete cluster node", msg)
+		return
+	}
 }
 
 func (r *NodeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/provider/resource_node_test.go
+++ b/provider/resource_node_test.go
@@ -135,7 +135,14 @@ func TestNodeResource_Delete_InboundsAttached(t *testing.T) {
 	}
 }
 
-func TestNodeResource_Delete_AlreadyGone(t *testing.T) {
+// TestNodeResource_Delete_ToleratesNotFound verifies the defensive record-
+// not-found branch in Delete. Note: the real 3x-ui panel returns SUCCESS for
+// deleting an already-absent node (service/node.go Delete ignores the First
+// error and gorm Delete with WHERE does not error on zero rows), so the
+// realistic 'already gone' path is covered by TestNodeResource_Delete_Success.
+// This test pins resilience to a hypothetical record-not-found response so
+// the guard at resource_node.go does not regress into a hard error.
+func TestNodeResource_Delete_ToleratesNotFound(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/login":
@@ -156,9 +163,9 @@ func TestNodeResource_Delete_AlreadyGone(t *testing.T) {
 	state := nodeResourceDeleteState(t, r, "7")
 	var resp resource.DeleteResponse
 	r.Delete(context.Background(), resource.DeleteRequest{State: state}, &resp)
-	// Out-of-band deletion should be treated as success (already gone).
+	// A record-not-found on delete must be tolerated (treated as already gone).
 	if resp.Diagnostics.HasError() {
-		t.Fatalf("unexpected error on already-gone Delete: %v", resp.Diagnostics)
+		t.Fatalf("unexpected error on record-not-found Delete: %v", resp.Diagnostics)
 	}
 }
 

--- a/provider/resource_node_test.go
+++ b/provider/resource_node_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -83,22 +82,83 @@ func TestNodeResource_Configure(t *testing.T) {
 	}
 }
 
-func TestNodeResource_Delete_NotYetImplemented(t *testing.T) {
-	r := &NodeResource{}
-	var resp resource.DeleteResponse
-	r.Delete(context.Background(), resource.DeleteRequest{}, &resp)
-	// Delete is a placeholder for M2 — must emit a warning, no error.
-	hasWarning := false
-	for _, d := range resp.Diagnostics {
-		if d.Severity() == diag.SeverityWarning {
-			hasWarning = true
+func TestNodeResource_Delete_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/del/7":
+			w.Write(okResponse(nil))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
 		}
-	}
-	if !hasWarning {
-		t.Fatal("expected a warning diagnostic on Delete (M3 TODO)")
-	}
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+	state := nodeResourceDeleteState(t, r, "7")
+	var resp resource.DeleteResponse
+	r.Delete(context.Background(), resource.DeleteRequest{State: state}, &resp)
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unexpected error on Delete: %v", resp.Diagnostics)
+	}
+}
+
+func TestNodeResource_Delete_InboundsAttached(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/del/7":
+			// DB-002 guard: panel refuses with success:false mentioning inbounds.
+			w.Write(failResponse("cannot delete node: 2 inbound(s) still attached to it"))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+	state := nodeResourceDeleteState(t, r, "7")
+	var resp resource.DeleteResponse
+	r.Delete(context.Background(), resource.DeleteRequest{State: state}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error when inbounds are still attached")
+	}
+}
+
+func TestNodeResource_Delete_AlreadyGone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/del/7":
+			w.Write(failResponse("obtain (record not found)"))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+	state := nodeResourceDeleteState(t, r, "7")
+	var resp resource.DeleteResponse
+	r.Delete(context.Background(), resource.DeleteRequest{State: state}, &resp)
+	// Out-of-band deletion should be treated as success (already gone).
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on already-gone Delete: %v", resp.Diagnostics)
 	}
 }
 
@@ -512,23 +572,19 @@ func nodeResourcePlan(t *testing.T, r *NodeResource, vals map[string]any) tfsdk.
 			out[k] = tftypes.NewValue(tftypes.String, nil)
 		}
 	}
-	if v, ok := vals["name"]; ok {
-		out["name"] = tftypes.NewValue(tftypes.String, v)
-	}
-	if v, ok := vals["address"]; ok {
-		out["address"] = tftypes.NewValue(tftypes.String, v)
+	stringFields := []string{"name", "address", "scheme", "id", "remark", "base_path",
+		"api_token", "tls_verify_mode", "pinned_cert_sha256",
+		"inbound_sync_mode", "outbound_tag"}
+	for _, k := range stringFields {
+		if v, ok := vals[k]; ok {
+			out[k] = tftypes.NewValue(tftypes.String, v)
+		}
 	}
 	if v, ok := vals["port"]; ok {
 		out["port"] = tftypes.NewValue(tftypes.Number, v)
 	}
-	if v, ok := vals["scheme"]; ok {
-		out["scheme"] = tftypes.NewValue(tftypes.String, v)
-	}
 	if v, ok := vals["enable"]; ok {
 		out["enable"] = tftypes.NewValue(tftypes.Bool, v)
-	}
-	if v, ok := vals["id"]; ok {
-		out["id"] = tftypes.NewValue(tftypes.String, v)
 	}
 	_ = objType
 	return tfsdk.Plan{
@@ -550,19 +606,26 @@ func newNodeResourceCreateResponse(t *testing.T, r *NodeResource) resource.Creat
 	}
 }
 
-// TestNodeResource_Update_Placeholder covers the M2 Update placeholder: it
-// re-reads and emits the "not yet implemented" warning. Real update is M3.
-func TestNodeResource_Update_Placeholder(t *testing.T) {
+// TestNodeResource_Update covers the real M3 Update: form-POST
+// /panel/api/nodes/update/:id then re-read GET /get/:id. The server restarts
+// xray itself on outbound_tag change, so the provider does not.
+func TestNodeResource_Update(t *testing.T) {
+	var updatedForm string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/login":
 			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
 			w.Write(okResponse(nil))
 			return
+		case "/panel/api/nodes/update/7":
+			r.ParseForm()
+			updatedForm = r.Form.Encode()
+			w.Write(okResponse(nil))
+			return
 		case "/panel/api/nodes/get/7":
 			w.Write(okResponse(map[string]any{
 				"id": 7, "name": "de-fra-1", "address": "node1.example.com",
-				"port": 2053, "enable": true,
+				"port": 2053, "enable": false, "remark": "renamed",
 			}))
 			return
 		default:
@@ -575,19 +638,55 @@ func TestNodeResource_Update_Placeholder(t *testing.T) {
 	r := &NodeResource{client: newTestClient(t, srv.URL)}
 	plan := nodeResourcePlan(t, r, map[string]any{
 		"name": "de-fra-1", "address": "node1.example.com", "port": int64(2053),
-		"id": "7",
+		"id": "7", "remark": "renamed",
 	})
 
 	resp := newNodeResourceUpdateResponse(t, r)
 	r.Update(context.Background(), resource.UpdateRequest{Plan: plan}, &resp)
-	hasWarning := false
-	for _, d := range resp.Diagnostics {
-		if d.Severity() == diag.SeverityWarning {
-			hasWarning = true
-		}
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on Update: %v", resp.Diagnostics)
 	}
-	if !hasWarning {
-		t.Fatal("expected the M3-TODO warning on Update")
+	// The update form must carry the managed field changes.
+	if !contains(updatedForm, "remark=renamed") {
+		t.Fatalf("update form missing remark: %q", updatedForm)
+	}
+
+	var state NodeResourceModel
+	resp.State.Get(context.Background(), &state)
+	if state.Remark.ValueString() != "renamed" {
+		t.Fatalf("expected re-read remark 'renamed', got %q", state.Remark.ValueString())
+	}
+}
+
+func TestNodeResource_Update_RemovesOnNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/update/7":
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/get/7":
+			// Node vanished between update and re-read.
+			w.Write(failResponse("obtain (record not found)"))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+	plan := nodeResourcePlan(t, r, map[string]any{
+		"name": "de-fra-1", "address": "node1.example.com", "port": int64(2053), "id": "7",
+	})
+	resp := newNodeResourceUpdateResponse(t, r)
+	r.Update(context.Background(), resource.UpdateRequest{Plan: plan}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on Update re-read not-found: %v", resp.Diagnostics)
 	}
 }
 
@@ -607,5 +706,113 @@ func newNodeResourceUpdateResponse(t *testing.T, r *NodeResource) resource.Updat
 			Schema: schemaResp.Schema,
 			Raw:    tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil),
 		},
+	}
+}
+
+// nodeResourceDeleteState builds a tfsdk.State with just the id, for Delete.
+func nodeResourceDeleteState(t *testing.T, r *NodeResource, id string) tfsdk.State {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	ctx := context.Background()
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	vals := map[string]tftypes.Value{}
+	for k := range schemaResp.Schema.Attributes {
+		vals[k] = tftypes.NewValue(objType.AttributeTypes[k], nil)
+	}
+	vals["id"] = tftypes.NewValue(tftypes.String, id)
+	return tfsdk.State{
+		Schema: schemaResp.Schema,
+		Raw:    tftypes.NewValue(objType, vals),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Client methods: UpdateNode / DeleteNode
+// ---------------------------------------------------------------------------
+
+func TestUpdateNode(t *testing.T) {
+	var receivedForm string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/update/7":
+			r.ParseForm()
+			receivedForm = r.Form.Encode()
+			w.Write(okResponse(nil))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	err := client.UpdateNode(context.Background(), 7, &Node{
+		Name: "de-fra-1", Scheme: "https", Address: "node1.example.com",
+		Port: 2053, Remark: "updated-remark", OutboundTag: "proxy-out",
+		InboundTags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("UpdateNode error: %v", err)
+	}
+	for _, want := range []string{"remark=updated-remark", "outboundTag=proxy-out", "address=node1.example.com"} {
+		if !contains(receivedForm, want) {
+			t.Fatalf("update form missing %q in %q", want, receivedForm)
+		}
+	}
+}
+
+func TestUpdateNode_NilAndZeroID(t *testing.T) {
+	client := newTestClient(t, "http://localhost:0")
+	if err := client.UpdateNode(context.Background(), 7, nil); err == nil {
+		t.Fatal("expected error on nil node")
+	}
+	if err := client.UpdateNode(context.Background(), 0, &Node{Name: "x"}); err == nil {
+		t.Fatal("expected error on zero id")
+	}
+}
+
+func TestDeleteNode(t *testing.T) {
+	var delPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/del/7":
+			delPath = r.URL.Path
+			// Gin uses POST for delete (not DELETE); confirm the method too.
+			if r.Method != http.MethodPost {
+				w.Write(failResponse("method not allowed"))
+				return
+			}
+			w.Write(okResponse(nil))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	if err := client.DeleteNode(context.Background(), 7); err != nil {
+		t.Fatalf("DeleteNode error: %v", err)
+	}
+	if delPath != "/panel/api/nodes/del/7" {
+		t.Fatalf("expected del hit on /panel/api/nodes/del/7, got %q", delPath)
+	}
+}
+
+func TestDeleteNode_ZeroID(t *testing.T) {
+	client := newTestClient(t, "http://localhost:0")
+	if err := client.DeleteNode(context.Background(), 0); err == nil {
+		t.Fatal("expected error on zero id")
 	}
 }


### PR DESCRIPTION
## Summary

M3 of the **Multi-node (cluster) management** milestone (#4). Replaces the M2 Update/Delete placeholders in `threexui_node` with real implementations, completing full CRUD. Verified against the `3x-ui-3.4.1` snapshot — endpoint subpaths and handler behaviour checked directly (lesson learned from M2's path bug).

## What's implemented

- **Update**: form-POST `/panel/api/nodes/update/:id`, then re-read `/get/:id` for observed state. The **3x-ui controller restarts the Xray core itself** when `outbound_tag` changes (`controller/node.go:180-181`) and runs `ensureReachable`, so the provider does **NOT** call `RestartXrayService` — this differs from `threexui_inbound`'s `restart_xray = true` pattern. Re-read not-found → remove from state.
- **Delete**: POST `/panel/api/nodes/del/:id` (gin uses POST, not DELETE). 3x-ui refuses to delete a node that still owns inbounds (DB-002, #314 R3); the provider surfaces that as a clear error so the operator detaches the inbounds first. Out-of-band deletion (record not found) is treated as success.

## Client helpers
- `UpdateNode(ctx, id, *Node)` — POST `/update/:id` with `nodeToForm`; returns nothing (handler echoes only a status message).
- `DeleteNode(ctx, id)` — POST `/del/:id`.

## Tests (unit, high patch coverage)
- `TestNodeResource_Update` (form fields + re-read) / `_Update_RemovesOnNotFound`
- `TestNodeResource_Delete_Success` / `_InboundsAttached` / `_AlreadyGone`
- `TestUpdateNode` / `_NilAndZeroID`, `TestDeleteNode` / `_ZeroID`
- Removed the M2 placeholder tests (Delete-warning / Update-warning) since the behaviour is now real.

## Checks
- `go vet ./...`, `golangci-lint run ./provider/` (0 issues), `go build ./...` — green.
- `go test ./provider/` — green. Coverage on `resource_node.go`: `Create` 93%, `Update` 61%, `Delete` 81%, `flattenNodeToModel` 98%, `Schema`/`Configure`/`parseNodeID`/`nodeFromModel` 100%. Uncovered lines are error-path diagnostics and framework-delegated `ImportState`.
- Pre-commit (fmt/vet/lint/build/markdownlint) green.
- Acc-tests remain deferred (no second-panel test harness) — same rationale as M2, tracked under M4's acc-test follow-up.

## Docs
- `docs/resources/node.md`: removed "M2 placeholder" scope notes; added "Delete behaviour" section + "Xray restart on outbound_tag change" note.
- `AGENTS.md`: rewrote the Cluster node section to reflect real Update/Delete + server-side restart; documented the exact gin subpaths.
- 7 README locales: resource row updated to drop the "(Create/Read/Import)" qualifier (now full CRUD).

## Non-goals (follow-up)
- Write-only `api_token_wo` / `pinned_cert_sha256_wo` — M4 (#319), the last item in the milestone.
- Acc-tests across the node lifecycle — needs a second container; noted for the M4 follow-up.

Closes #318.
