### PR TITLE
feat(node): write-only secrets for threexui_node (M4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Each secret gets three attributes: old `Sensitive` attr + `WriteOnly` attr + `_w
 | `panel_telegram` | `tg_bot_token` | `tg_bot_token_wo` | `tg_bot_token_wo_version` |
 | `panel_email` | `smtp_password` | `smtp_password_wo` | `smtp_password_wo_version` |
 | `panel_general` | `ldap_password` | `ldap_password_wo` | `ldap_password_wo_version` |
+| `threexui_node` | `api_token`, `pinned_cert_sha256` | `api_token_wo`, `pinned_cert_sha256_wo` | `api_token_wo_version`, `pinned_cert_sha256_wo_version` |
 
 - `PreferWriteOnlyAttribute` validator warns on TF >= 1.11 when using old attr.
 - `int64validator.AlsoRequires` enforces that `*_wo_version` can only be set with `*_wo`.
@@ -189,7 +190,10 @@ POSTs `/del/:id`; 3x-ui refuses to delete a node that still owns inbounds
 (DB-002, #314 R3) — surfaced as a clear error so the operator detaches the
 inbounds first. Import is by numeric id (`ImportStatePassthroughID`). `api_token`
 and `pinned_cert_sha256` are `Sensitive` (panel returns them raw, no redaction —
-issue #314 R1); write-only `_wo` variants are M4 (issue #319). Schema lives in `node_schema.go`;
+issue #314 R1) with write-only `_wo` variants following the settings-style
+strategy (`api_token_wo`+`_wo_version`, `pinned_cert_sha256_wo`+`_wo_version`;
+`resolveNodeSecretsWO`/`resolveNodeSecretsWOUpdate` + ModifyPlan via the
+shared `modifyPlanWOVersion` generic). Schema lives in `node_schema.go`;
 the typed `Node` model is shared with the `threexui_nodes` data source (`types.go`).
 
 ### HTTP client (`client.go`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ The 3x-ui panel issues and stores secrets that this provider reads and writes. T
 | `threexui_panel_telegram` | `bot_token`, `chat_id` |
 | `threexui_panel_email` | `smtp_password` |
 | `threexui_panel_user` | `old_password`, `new_password` |
-| `threexui_node` | `api_token`, `pinned_cert_sha256` |
+| `threexui_node` | `api_token` / `api_token_wo`, `pinned_cert_sha256` / `pinned_cert_sha256_wo` |
 | `threexui_xray_outbounds` | per-protocol credentials (e.g. `password`, `users[].password`) |
 | Data sources | `threexui_inbounds.inbounds`, `threexui_nodes.nodes` (`apiToken`, `pinnedCertSha256`), `threexui_settings.json`, `threexui_xray_config.json` (full payloads) |
 

--- a/docs/resources/node.md
+++ b/docs/resources/node.md
@@ -44,11 +44,15 @@ terraform import threexui_node.fra1 7
 - `remark` (Optional, String) - Free-form note.
 - `scheme` (Optional, String) - `http` or `https`. Defaults to `https`.
 - `base_path` (Optional, String) - Node web API base path. Defaults to `/`.
-- `api_token` (Optional, String, Sensitive) - Bearer API token the central panel uses to authenticate to the node. Required unless `tls_verify_mode` is `mtls`. The panel returns this raw without redaction.
+- `api_token` (Optional, String, Sensitive) - Bearer API token the central panel uses to authenticate to the node. Required unless `tls_verify_mode` is `mtls`. The panel returns this raw without redaction. Prefer the write-only `api_token_wo` on TF 1.11+.
+- `api_token_wo` (Optional, String, Write-Only) - Write-only node API token (Terraform 1.11+ / OpenTofu 1.11+). Pair with `api_token_wo_version` to rotate.
+- `api_token_wo_version` (Optional, Number) - Increment to rotate `api_token_wo`. Each change sends the current `_wo` value to the panel; requires `api_token_wo`.
 - `enable` (Optional, Bool) - Whether the node is enabled. Defaults to `true`.
 - `allow_private_address` (Optional, Bool) - Allow the node address to resolve to a private IP. Defaults to `false`.
 - `tls_verify_mode` (Optional, String) - `verify`, `skip`, `pin`, or `mtls`. Defaults to `verify`.
-- `pinned_cert_sha256` (Optional, String, Sensitive) - Pinned certificate fingerprint, required when `tls_verify_mode` is `pin`.
+- `pinned_cert_sha256` (Optional, String, Sensitive) - Pinned certificate fingerprint, required when `tls_verify_mode` is `pin`. Prefer the write-only `pinned_cert_sha256_wo` on TF 1.11+.
+- `pinned_cert_sha256_wo` (Optional, String, Write-Only) - Write-only pinned certificate fingerprint (Terraform 1.11+ / OpenTofu 1.11+). Pair with `pinned_cert_sha256_wo_version` to rotate.
+- `pinned_cert_sha256_wo_version` (Optional, Number) - Increment to rotate `pinned_cert_sha256_wo`; requires `pinned_cert_sha256_wo`.
 - `inbound_sync_mode` (Optional, String) - `all` or `selected`. Defaults to `all`.
 - `inbound_tags` (Optional, List of String) - Inbound tags to sync when `inbound_sync_mode` is `selected`.
 - `outbound_tag` (Optional, String) - Xray outbound/balancer tag bridging this node.
@@ -85,4 +89,4 @@ Import is supported by numeric id:
 terraform import threexui_node.NAME <id>
 ```
 
-> **Scope note:** Write-only secret attributes (`api_token_wo`, `pinned_cert_sha256_wo`) are M4 (#319). Until then, `api_token`/`pinned_cert_sha256` are plain `Sensitive`.
+> **Scope note:** Write-only secret attributes (`api_token_wo` + `api_token_wo_version`, `pinned_cert_sha256_wo` + `pinned_cert_sha256_wo_version`) follow the AWS/Azure write-only pattern (Terraform 1.11+ / OpenTofu 1.11+). Set the `_wo` value and bump the `_wo_version` to rotate; the plain attribute keeps the masked value in state. The panel returns secrets raw (#314 R1), so this uses the settings-style strategy (ModifyPlan marks the plain attr Unknown on version change). On TF >= 1.11 using the plain `Sensitive` attr emits a `PreferWriteOnlyAttribute` warning.

--- a/provider/node_schema.go
+++ b/provider/node_schema.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -21,21 +22,25 @@ import (
 // (Computed). See .pi/m2-contract.md and 3x-ui-3.4.1/internal/database/model/model.go.
 type NodeResourceModel struct {
 	// Managed (user-editable).
-	ID                  types.String   `tfsdk:"id"`
-	Name                types.String   `tfsdk:"name"`
-	Remark              types.String   `tfsdk:"remark"`
-	Scheme              types.String   `tfsdk:"scheme"`
-	Address             types.String   `tfsdk:"address"`
-	Port                types.Int64    `tfsdk:"port"`
-	BasePath            types.String   `tfsdk:"base_path"`
-	ApiToken            types.String   `tfsdk:"api_token"`
-	Enable              types.Bool     `tfsdk:"enable"`
-	AllowPrivateAddress types.Bool     `tfsdk:"allow_private_address"`
-	TlsVerifyMode       types.String   `tfsdk:"tls_verify_mode"`
-	PinnedCertSha256    types.String   `tfsdk:"pinned_cert_sha256"`
-	InboundSyncMode     types.String   `tfsdk:"inbound_sync_mode"`
-	InboundTags         []types.String `tfsdk:"inbound_tags"`
-	OutboundTag         types.String   `tfsdk:"outbound_tag"`
+	ID                        types.String   `tfsdk:"id"`
+	Name                      types.String   `tfsdk:"name"`
+	Remark                    types.String   `tfsdk:"remark"`
+	Scheme                    types.String   `tfsdk:"scheme"`
+	Address                   types.String   `tfsdk:"address"`
+	Port                      types.Int64    `tfsdk:"port"`
+	BasePath                  types.String   `tfsdk:"base_path"`
+	ApiToken                  types.String   `tfsdk:"api_token"`
+	ApiTokenWO                types.String   `tfsdk:"api_token_wo"`
+	ApiTokenWOVersion         types.Int64    `tfsdk:"api_token_wo_version"`
+	Enable                    types.Bool     `tfsdk:"enable"`
+	AllowPrivateAddress       types.Bool     `tfsdk:"allow_private_address"`
+	TlsVerifyMode             types.String   `tfsdk:"tls_verify_mode"`
+	PinnedCertSha256          types.String   `tfsdk:"pinned_cert_sha256"`
+	PinnedCertSha256WO        types.String   `tfsdk:"pinned_cert_sha256_wo"`
+	PinnedCertSha256WOVersion types.Int64    `tfsdk:"pinned_cert_sha256_wo_version"`
+	InboundSyncMode           types.String   `tfsdk:"inbound_sync_mode"`
+	InboundTags               []types.String `tfsdk:"inbound_tags"`
+	OutboundTag               types.String   `tfsdk:"outbound_tag"`
 
 	// Observed identity / heartbeat state (Computed).
 	Guid          types.String  `tfsdk:"guid"`
@@ -123,9 +128,28 @@ func nodeResourceSchema() schema.Schema {
 			"api_token": schema.StringAttribute{
 				Optional:  true,
 				Sensitive: true,
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("api_token_wo")),
+				},
 				Description: "Bearer API token used by the central panel to authenticate to the node's web API. " +
 					"Required unless tls_verify_mode is 'mtls' (mTLS nodes authenticate via client certificate). " +
-					"The panel returns this value raw without redaction, so it is marked Sensitive.",
+					"The panel returns this value raw without redaction, so it is marked Sensitive. " +
+					"Prefer the write-only api_token_wo (Terraform 1.11+ / OpenTofu 1.11+).",
+			},
+			"api_token_wo": schema.StringAttribute{
+				Optional:    true,
+				WriteOnly:   true,
+				Description: "Write-only node API token (Terraform 1.11+ / OpenTofu 1.11+). Pair with api_token_wo_version to rotate.",
+			},
+			"api_token_wo_version": schema.Int64Attribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("api_token_wo")),
+				},
+				Description: "Increment to rotate the write-only api_token_wo. Each change sends the current _wo value to the panel.",
 			},
 			"enable": schema.BoolAttribute{
 				Optional:    true,
@@ -149,9 +173,28 @@ func nodeResourceSchema() schema.Schema {
 				Description: "TLS verification mode for the node web API. One of verify, skip, pin, mtls. Defaults to verify.",
 			},
 			"pinned_cert_sha256": schema.StringAttribute{
+				Optional:  true,
+				Sensitive: true,
+				Validators: []validator.String{
+					stringvalidator.PreferWriteOnlyAttribute(path.MatchRoot("pinned_cert_sha256_wo")),
+				},
+				Description: "Pinned certificate fingerprint (SHA-256) required when tls_verify_mode is 'pin'. Returned raw by the panel, hence Sensitive. " +
+					"Prefer the write-only pinned_cert_sha256_wo (Terraform 1.11+ / OpenTofu 1.11+).",
+			},
+			"pinned_cert_sha256_wo": schema.StringAttribute{
 				Optional:    true,
-				Sensitive:   true,
-				Description: "Pinned certificate fingerprint (SHA-256) required when tls_verify_mode is 'pin'. Returned raw by the panel, hence Sensitive.",
+				WriteOnly:   true,
+				Description: "Write-only pinned certificate fingerprint (Terraform 1.11+ / OpenTofu 1.11+). Pair with pinned_cert_sha256_wo_version to rotate.",
+			},
+			"pinned_cert_sha256_wo_version": schema.Int64Attribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("pinned_cert_sha256_wo")),
+				},
+				Description: "Increment to rotate the write-only pinned_cert_sha256_wo.",
 			},
 			"inbound_sync_mode": schema.StringAttribute{
 				Optional: true,

--- a/provider/resource_node.go
+++ b/provider/resource_node.go
@@ -51,20 +51,35 @@ func (r *NodeResource) Configure(_ context.Context, req resource.ConfigureReques
 // new sensitive value from Apply instead of rejecting it as "inconsistent
 // values for sensitive" (the write-only value is read from req.Config and
 // copied into the plain field by resolveNodeSecretsWO at Apply time).
+//
+// Inlined rather than calling the shared modifyPlanWOVersion generic twice:
+// that generic re-reads req.Plan and overwrites the whole resp.Plan on each
+// call, so a second call would erase the Unknown mark set by the first
+// (simultaneous rotation of both secrets). threexui_node is the first
+// resource with two write-only secrets; the settings resources have one each
+// and use the generic directly.
 func (r *NodeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	modifyPlanWOVersion(
-		ctx, req, resp,
-		func(m NodeResourceModel) types.Int64 { return m.ApiTokenWOVersion },
-		func(m *NodeResourceModel, v types.String) { m.ApiToken = v },
-	)
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+	var plan, state NodeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	modifyPlanWOVersion(
-		ctx, req, resp,
-		func(m NodeResourceModel) types.Int64 { return m.PinnedCertSha256WOVersion },
-		func(m *NodeResourceModel, v types.String) { m.PinnedCertSha256 = v },
-	)
+	changed := false
+	if woVersionTriggered(plan.ApiTokenWOVersion, state.ApiTokenWOVersion) {
+		plan.ApiToken = types.StringUnknown()
+		changed = true
+	}
+	if woVersionTriggered(plan.PinnedCertSha256WOVersion, state.PinnedCertSha256WOVersion) {
+		plan.PinnedCertSha256 = types.StringUnknown()
+		changed = true
+	}
+	if changed {
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	}
 }
 
 func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -303,6 +318,11 @@ func flattenNodeToModel(n *Node, m *NodeResourceModel) {
 	if n == nil {
 		return
 	}
+	// Note: *_wo_version fields are intentionally NOT overwritten here — flatten
+	// mutates the existing model in place (Create/Update pass &plan), so the
+	// planned wo_version survives into state. (The settings resources instead
+	// build a fresh model in flatten* and must call preserveWOVersion; node does
+	// not because it mutates in place.)
 	m.Name = types.StringValue(n.Name)
 	if n.Remark != "" {
 		m.Remark = types.StringValue(n.Remark)

--- a/provider/resource_node.go
+++ b/provider/resource_node.go
@@ -15,6 +15,7 @@ var (
 	_ resource.Resource                = &NodeResource{}
 	_ resource.ResourceWithConfigure   = &NodeResource{}
 	_ resource.ResourceWithImportState = &NodeResource{}
+	_ resource.ResourceWithModifyPlan  = &NodeResource{}
 )
 
 type NodeResource struct {
@@ -45,12 +46,40 @@ func (r *NodeResource) Configure(_ context.Context, req resource.ConfigureReques
 	r.client = client
 }
 
+// ModifyPlan marks the plain secret attributes (api_token, pinned_cert_sha256)
+// as Unknown when their *_wo_version trigger changes, so Terraform accepts the
+// new sensitive value from Apply instead of rejecting it as "inconsistent
+// values for sensitive" (the write-only value is read from req.Config and
+// copied into the plain field by resolveNodeSecretsWO at Apply time).
+func (r *NodeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	modifyPlanWOVersion(
+		ctx, req, resp,
+		func(m NodeResourceModel) types.Int64 { return m.ApiTokenWOVersion },
+		func(m *NodeResourceModel, v types.String) { m.ApiToken = v },
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	modifyPlanWOVersion(
+		ctx, req, resp,
+		func(m NodeResourceModel) types.Int64 { return m.PinnedCertSha256WOVersion },
+		func(m *NodeResourceModel, v types.String) { m.PinnedCertSha256 = v },
+	)
+}
+
 func (r *NodeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan NodeResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	var config NodeResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolveNodeSecretsWO(&plan, config)
 
 	in := nodeFromModel(&plan)
 
@@ -121,6 +150,18 @@ func (r *NodeResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	var state NodeResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var config NodeResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resolveNodeSecretsWOUpdate(&plan, state, config)
 
 	id, err := parseNodeID(plan.ID.ValueString())
 	if err != nil {
@@ -196,6 +237,35 @@ func parseNodeID(id string) (int, error) {
 		return 0, fmt.Errorf("invalid node id: %s", id)
 	}
 	return parsed, nil
+}
+
+// resolveNodeSecretsWO copies the write-only secret values from config into
+// the plain fields before Create. Write-only values live only in req.Config
+// (the framework nulls them in plan/state), so without this the panel would
+// never receive the new secret on first apply. The settings-style strategy
+// applies because the panel returns secrets raw (#314 R1) and flatten reads
+// them back, which would otherwise clash with a null plan value.
+func resolveNodeSecretsWO(plan *NodeResourceModel, config NodeResourceModel) {
+	if !config.ApiTokenWO.IsNull() && !config.ApiTokenWO.IsUnknown() {
+		plan.ApiToken = config.ApiTokenWO
+	}
+	if !config.PinnedCertSha256WO.IsNull() && !config.PinnedCertSha256WO.IsUnknown() {
+		plan.PinnedCertSha256 = config.PinnedCertSha256WO
+	}
+}
+
+// resolveNodeSecretsWOUpdate copies the write-only secret into the plain field
+// on Update only when the *_wo_version trigger changed (version bump, or first
+// use when state has none). This avoids resending the secret on every update.
+func resolveNodeSecretsWOUpdate(plan *NodeResourceModel, state, config NodeResourceModel) {
+	if !config.ApiTokenWO.IsNull() && !config.ApiTokenWO.IsUnknown() &&
+		woVersionTriggered(plan.ApiTokenWOVersion, state.ApiTokenWOVersion) {
+		plan.ApiToken = config.ApiTokenWO
+	}
+	if !config.PinnedCertSha256WO.IsNull() && !config.PinnedCertSha256WO.IsUnknown() &&
+		woVersionTriggered(plan.PinnedCertSha256WOVersion, state.PinnedCertSha256WOVersion) {
+		plan.PinnedCertSha256 = config.PinnedCertSha256WO
+	}
 }
 
 // nodeFromModel builds the API Node from the managed attributes of the model.

--- a/provider/resource_node_test.go
+++ b/provider/resource_node_test.go
@@ -972,3 +972,142 @@ func setPlanValue(t *testing.T, r *NodeResource, plan tfsdk.Plan, key, val strin
 // ModifyPlan requires fully initialising resp.Plan's Schema/Raw, which is
 // fragile; the resolve + woVersionTriggered unit tests below cover the
 // behaviour that matters.
+
+// ---------------------------------------------------------------------------
+// ModifyPlan (M4, inlined for dual-secret support)
+// ---------------------------------------------------------------------------
+
+// modifyPlanFixture builds a Plan/State pair for ModifyPlan tests, with the
+// given *_wo_version values for both secrets and a concrete api_token.
+func modifyPlanFixture(t *testing.T, r *NodeResource, apiWOVer, pinWOVer, stateAPIWOVer, statePinWOVer int64) (tfsdk.Plan, tfsdk.State) {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	ctx := context.Background()
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+
+	build := func(apiV, pinV int64) tfsdk.Plan {
+		vals := map[string]tftypes.Value{}
+		for k := range schemaResp.Schema.Attributes {
+			switch k {
+			case "port":
+				vals[k] = tftypes.NewValue(tftypes.Number, 2053)
+			case "enable", "allow_private_address", "config_dirty", "transitive":
+				vals[k] = tftypes.NewValue(tftypes.Bool, nil)
+			case "inbound_tags":
+				vals[k] = tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, nil)
+			case "api_token_wo_version":
+				vals[k] = tftypes.NewValue(tftypes.Number, apiV)
+			case "pinned_cert_sha256_wo_version":
+				vals[k] = tftypes.NewValue(tftypes.Number, pinV)
+			case "cpu_pct", "mem_pct", "latency_ms", "last_heartbeat", "uptime_secs",
+				"net_up", "net_down", "config_dirty_at", "inbound_count", "client_count",
+				"online_count", "active_count", "disabled_count", "depleted_count",
+				"created_at", "updated_at":
+				vals[k] = tftypes.NewValue(tftypes.Number, nil)
+			default:
+				vals[k] = tftypes.NewValue(tftypes.String, nil)
+			}
+		}
+		vals["id"] = tftypes.NewValue(tftypes.String, "1")
+		vals["api_token"] = tftypes.NewValue(tftypes.String, "prior-token")
+		return tfsdk.Plan{Schema: schemaResp.Schema, Raw: tftypes.NewValue(objType, vals)}
+	}
+
+	plan := build(apiWOVer, pinWOVer)
+	state := build(stateAPIWOVer, statePinWOVer)
+	return plan, tfsdk.State(state)
+}
+
+// TestNodeResource_ModifyPlan_BothSecretsTriggered is the regression test for
+// the dual-secret bug the M4 review caught: when both *_wo_version change at
+// once, BOTH plain secrets must be marked Unknown (a naive double call to the
+// shared modifyPlanWOVersion generic would erase the first mark).
+func TestNodeResource_ModifyPlan_BothSecretsTriggered(t *testing.T) {
+	r := &NodeResource{}
+	ctx := context.Background()
+	plan, st := modifyPlanFixture(t, r, 2, 2, 1, 1) // both bumped
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	resp := &resource.ModifyPlanResponse{
+		Plan: tfsdk.Plan{Schema: schemaResp.Schema, Raw: tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil)},
+	}
+	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, State: st}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	var out NodeResourceModel
+	resp.Plan.Get(ctx, &out)
+	if !out.ApiToken.IsUnknown() {
+		t.Fatalf("expected api_token marked Unknown on simultaneous rotation, got %v", out.ApiToken)
+	}
+	if !out.PinnedCertSha256.IsUnknown() {
+		t.Fatalf("expected pinned_cert_sha256 marked Unknown on simultaneous rotation, got %v", out.PinnedCertSha256)
+	}
+}
+
+func TestNodeResource_ModifyPlan_SingleSecretTriggered(t *testing.T) {
+	r := &NodeResource{}
+	ctx := context.Background()
+	// Only api_token_wo_version bumps; pinned stays the same.
+	plan, st := modifyPlanFixture(t, r, 2, 1, 1, 1)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	resp := &resource.ModifyPlanResponse{
+		Plan: tfsdk.Plan{Schema: schemaResp.Schema, Raw: tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil)},
+	}
+	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, State: st}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	var out NodeResourceModel
+	resp.Plan.Get(ctx, &out)
+	if !out.ApiToken.IsUnknown() {
+		t.Fatalf("expected api_token Unknown, got %v", out.ApiToken)
+	}
+	if out.PinnedCertSha256.IsUnknown() {
+		t.Fatal("pinned_cert_sha256 must NOT be Unknown when its version is unchanged")
+	}
+}
+
+func TestNodeResource_ModifyPlan_NoTrigger(t *testing.T) {
+	r := &NodeResource{}
+	ctx := context.Background()
+	// No version change at all — ModifyPlan must be a no-op.
+	plan, st := modifyPlanFixture(t, r, 1, 1, 1, 1)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	resp := &resource.ModifyPlanResponse{
+		Plan: tfsdk.Plan{Schema: schemaResp.Schema, Raw: tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), nil)},
+	}
+	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, State: st}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	var out NodeResourceModel
+	resp.Plan.Get(ctx, &out)
+	if out.ApiToken.IsUnknown() {
+		t.Fatal("api_token must not be Unknown when no version changed")
+	}
+	if out.PinnedCertSha256.IsUnknown() {
+		t.Fatal("pinned_cert_sha256 must not be Unknown when no version changed")
+	}
+}
+
+// TestResolveNodeSecretsWOUpdate_PinnedCert rounds out the symmetric coverage
+// for the second write-only secret on the update path (api_token is covered by
+// the _TriggerBumped/_FirstUse/_NoTrigger tests above).
+func TestResolveNodeSecretsWOUpdate_PinnedCert(t *testing.T) {
+	plan := &NodeResourceModel{
+		PinnedCertSha256WOVersion: types.Int64Value(3),
+	}
+	state := NodeResourceModel{PinnedCertSha256WOVersion: types.Int64Value(2)}
+	config := NodeResourceModel{PinnedCertSha256WO: types.StringValue("rotated-pin")}
+	resolveNodeSecretsWOUpdate(plan, state, config)
+	if plan.PinnedCertSha256.ValueString() != "rotated-pin" {
+		t.Fatalf("expected pinned_cert_sha256 rotated, got %q", plan.PinnedCertSha256.ValueString())
+	}
+}

--- a/provider/resource_node_test.go
+++ b/provider/resource_node_test.go
@@ -509,7 +509,7 @@ func TestNodeResource_Create(t *testing.T) {
 	})
 
 	resp := newNodeResourceCreateResponse(t, r)
-	r.Create(context.Background(), resource.CreateRequest{Plan: plan}, &resp)
+	r.Create(context.Background(), resource.CreateRequest{Plan: plan, Config: planToConfig(plan)}, &resp)
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unexpected error on Create: %v", resp.Diagnostics)
 	}
@@ -548,7 +548,7 @@ func TestNodeResource_Create_ReachabilityError(t *testing.T) {
 		"name": "x", "address": "unreachable.example", "port": int64(2053),
 	})
 	resp := newNodeResourceCreateResponse(t, r)
-	r.Create(context.Background(), resource.CreateRequest{Plan: plan}, &resp)
+	r.Create(context.Background(), resource.CreateRequest{Plan: plan, Config: planToConfig(plan)}, &resp)
 	if !resp.Diagnostics.HasError() {
 		t.Fatal("expected error on unreachable node create")
 	}
@@ -567,7 +567,8 @@ func nodeResourcePlan(t *testing.T, r *NodeResource, vals map[string]any) tfsdk.
 		case "port", "latency_ms", "last_heartbeat", "uptime_secs", "net_up",
 			"net_down", "config_dirty_at", "inbound_count", "client_count",
 			"online_count", "active_count", "disabled_count", "depleted_count",
-			"created_at", "updated_at":
+			"created_at", "updated_at",
+			"api_token_wo_version", "pinned_cert_sha256_wo_version":
 			out[k] = tftypes.NewValue(tftypes.Number, nil)
 		case "enable", "allow_private_address", "config_dirty", "transitive":
 			out[k] = tftypes.NewValue(tftypes.Bool, nil)
@@ -580,8 +581,8 @@ func nodeResourcePlan(t *testing.T, r *NodeResource, vals map[string]any) tfsdk.
 		}
 	}
 	stringFields := []string{"name", "address", "scheme", "id", "remark", "base_path",
-		"api_token", "tls_verify_mode", "pinned_cert_sha256",
-		"inbound_sync_mode", "outbound_tag"}
+		"api_token", "api_token_wo", "pinned_cert_sha256", "pinned_cert_sha256_wo",
+		"tls_verify_mode", "inbound_sync_mode", "outbound_tag"}
 	for _, k := range stringFields {
 		if v, ok := vals[k]; ok {
 			out[k] = tftypes.NewValue(tftypes.String, v)
@@ -649,7 +650,7 @@ func TestNodeResource_Update(t *testing.T) {
 	})
 
 	resp := newNodeResourceUpdateResponse(t, r)
-	r.Update(context.Background(), resource.UpdateRequest{Plan: plan}, &resp)
+	r.Update(context.Background(), resource.UpdateRequest{Plan: plan, Config: planToConfig(plan), State: tfsdk.State(plan)}, &resp)
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unexpected error on Update: %v", resp.Diagnostics)
 	}
@@ -691,7 +692,7 @@ func TestNodeResource_Update_RemovesOnNotFound(t *testing.T) {
 		"name": "de-fra-1", "address": "node1.example.com", "port": int64(2053), "id": "7",
 	})
 	resp := newNodeResourceUpdateResponse(t, r)
-	r.Update(context.Background(), resource.UpdateRequest{Plan: plan}, &resp)
+	r.Update(context.Background(), resource.UpdateRequest{Plan: plan, Config: planToConfig(plan), State: tfsdk.State(plan)}, &resp)
 	if resp.Diagnostics.HasError() {
 		t.Fatalf("unexpected error on Update re-read not-found: %v", resp.Diagnostics)
 	}
@@ -823,3 +824,151 @@ func TestDeleteNode_ZeroID(t *testing.T) {
 		t.Fatal("expected error on zero id")
 	}
 }
+
+// planToConfig wraps a tfsdk.Plan's Schema/Raw into a tfsdk.Config so that
+// Create/Update requests in unit tests carry the write-only _wo values the
+// resource reads from req.Config.
+func planToConfig(plan tfsdk.Plan) tfsdk.Config {
+	return tfsdk.Config(plan)
+}
+
+// ---------------------------------------------------------------------------
+// Write-only secrets (M4): resolve + ModifyPlan
+// ---------------------------------------------------------------------------
+
+// resolveNodeSecretsWO must copy the _wo value from config into the plain
+// field on Create. This is the settings-style strategy (#314 R1).
+func TestResolveNodeSecretsWO_Create(t *testing.T) {
+	plan := &NodeResourceModel{}
+	config := NodeResourceModel{
+		ApiToken:           types.StringValue("from-state"),
+		ApiTokenWO:         types.StringValue("wo-secret"),
+		PinnedCertSha256:   types.StringValue("old-pin"),
+		PinnedCertSha256WO: types.StringValue("wo-pin"),
+	}
+	resolveNodeSecretsWO(plan, config)
+	if plan.ApiToken.ValueString() != "wo-secret" {
+		t.Fatalf("expected api_token copied from _wo, got %q", plan.ApiToken.ValueString())
+	}
+	if plan.PinnedCertSha256.ValueString() != "wo-pin" {
+		t.Fatalf("expected pinned_cert_sha256 copied from _wo, got %q", plan.PinnedCertSha256.ValueString())
+	}
+}
+
+// resolveNodeSecretsWO must be a no-op when no _wo value is configured
+// (plain path: state value survives).
+func TestResolveNodeSecretsWO_NoWOConfigured(t *testing.T) {
+	plan := &NodeResourceModel{ApiToken: types.StringValue("keep-me")}
+	config := NodeResourceModel{}
+	resolveNodeSecretsWO(plan, config)
+	if plan.ApiToken.ValueString() != "keep-me" {
+		t.Fatalf("plain api_token should be preserved, got %q", plan.ApiToken.ValueString())
+	}
+}
+
+// resolveNodeSecretsWOUpdate only copies the secret when the _wo_version
+// trigger changed (version bump OR first use when state has none).
+func TestResolveNodeSecretsWOUpdate_TriggerBumped(t *testing.T) {
+	plan := &NodeResourceModel{ApiTokenWOVersion: types.Int64Value(2)}
+	state := NodeResourceModel{ApiTokenWOVersion: types.Int64Value(1)}
+	config := NodeResourceModel{ApiTokenWO: types.StringValue("rotated")}
+	resolveNodeSecretsWOUpdate(plan, state, config)
+	if plan.ApiToken.ValueString() != "rotated" {
+		t.Fatalf("expected api_token rotated on version bump, got %q", plan.ApiToken.ValueString())
+	}
+}
+
+func TestResolveNodeSecretsWOUpdate_FirstUse(t *testing.T) {
+	plan := &NodeResourceModel{ApiTokenWOVersion: types.Int64Value(1)}
+	state := NodeResourceModel{ApiTokenWOVersion: types.Int64Null()}
+	config := NodeResourceModel{ApiTokenWO: types.StringValue("first")}
+	resolveNodeSecretsWOUpdate(plan, state, config)
+	if plan.ApiToken.ValueString() != "first" {
+		t.Fatalf("expected api_token set on first use, got %q", plan.ApiToken.ValueString())
+	}
+}
+
+func TestResolveNodeSecretsWOUpdate_NoTrigger(t *testing.T) {
+	// Version unchanged -> _wo value must NOT be resent (no-op update).
+	plan := &NodeResourceModel{
+		ApiToken:          types.StringValue("existing"),
+		ApiTokenWOVersion: types.Int64Value(1),
+	}
+	state := NodeResourceModel{ApiTokenWOVersion: types.Int64Value(1)}
+	config := NodeResourceModel{ApiTokenWO: types.StringValue("ignored")}
+	resolveNodeSecretsWOUpdate(plan, state, config)
+	if plan.ApiToken.ValueString() != "existing" {
+		t.Fatalf("expected api_token unchanged on no-trigger update, got %q", plan.ApiToken.ValueString())
+	}
+}
+
+// TestNodeResource_Create_WithWriteOnlyToken exercises the full Create path
+// where the secret is supplied via api_token_wo: the resource must send it to
+// the panel (the form carries the resolved value, not empty).
+func TestNodeResource_Create_WithWriteOnlyToken(t *testing.T) {
+	var receivedForm string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login":
+			http.SetCookie(w, &http.Cookie{Name: "3x-ui", Value: "sess"})
+			w.Write(okResponse(nil))
+			return
+		case "/panel/api/nodes/add":
+			r.ParseForm()
+			receivedForm = r.Form.Encode()
+			w.Write(okResponse(map[string]any{"id": 9, "name": "n", "address": "a", "port": 2053}))
+			return
+		case "/panel/api/nodes/get/9":
+			w.Write(okResponse(map[string]any{"id": 9, "name": "n", "address": "a", "port": 2053}))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	r := &NodeResource{client: newTestClient(t, srv.URL)}
+	plan := nodeResourcePlan(t, r, map[string]any{
+		"name": "n", "address": "a", "port": int64(2053),
+	})
+	// Supply the secret only via write-only in config.
+	planWO := setPlanValue(t, r, plan, "api_token_wo", "wo-create-secret")
+
+	resp := newNodeResourceCreateResponse(t, r)
+	r.Create(context.Background(), resource.CreateRequest{Plan: planWO, Config: planToConfig(planWO)}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %v", resp.Diagnostics)
+	}
+	if !contains(receivedForm, "apiToken=wo-create-secret") {
+		t.Fatalf("create form must carry the resolved write-only token; got %q", receivedForm)
+	}
+}
+
+// setPlanValue returns a copy of the plan with the given string attribute set.
+// Used to inject write-only values that nodeResourcePlan does not set by default.
+func setPlanValue(t *testing.T, r *NodeResource, plan tfsdk.Plan, key, val string) tfsdk.Plan {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
+	ctx := context.Background()
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	vals := map[string]tftypes.Value{}
+	_ = plan.Raw.As(&vals)
+	for k, v := range vals {
+		vals[k] = v
+	}
+	vals[key] = tftypes.NewValue(tftypes.String, val)
+	return tfsdk.Plan{
+		Schema: plan.Schema,
+		Raw:    tftypes.NewValue(objType, vals),
+	}
+}
+
+// NOTE: ModifyPlan itself is exercised end-to-end by the write-only acc
+// tests (M4 follow-up). Its core logic lives in the generic
+// modifyPlanWOVersion helper (already covered by the settings resources)
+// plus resolveNodeSecretsWO/Update (covered above). Directly unit-testing
+// ModifyPlan requires fully initialising resp.Plan's Schema/Raw, which is
+// fragile; the resolve + woVersionTriggered unit tests below cover the
+// behaviour that matters.


### PR DESCRIPTION
## Summary

M4 of the **Multi-node (cluster) management** milestone (#4) — the **final item**. Adds write-only secret attributes for the two node secrets (`api_token`, `pinned_cert_sha256`), following the existing AWS/Azure write-only pattern and the **settings-style strategy** (decided by #314 R1: the panel returns secrets raw, so the plain attribute must survive a re-read while the `_wo` value rotates).

This completes the milestone: `threexui_node` now has full CRUD + write-only secrets, paired with the `threexui_nodes` data source (M1).

## What's implemented

Each secret now has three attributes (old plain `Sensitive` + `_wo` WriteOnly + `_wo_version` trigger):
- `api_token` / `api_token_wo` / `api_token_wo_version`
- `pinned_cert_sha256` / `pinned_cert_sha256_wo` / `pinned_cert_sha256_wo_version`

Mirrors `panel_security` / `panel_telegram` exactly:
- **Schema** (`node_schema.go`): `PreferWriteOnlyAttribute` on the plain attrs; `WriteOnly` on `_wo`; `int64validator.AlsoRequires(_wo)` on `_wo_version`; `UseStateForUnknown` on `_wo_version`.
- **`resolveNodeSecretsWO`**: copies `_wo` → plain in **Create** (read from `req.Config`, since the framework nulls `_wo` in plan/state).
- **`resolveNodeSecretsWOUpdate`**: copies `_wo` → plain in **Update** only when the `_wo_version` trigger changed (version bump or first use) — avoids resending the secret on every update.
- **`ModifyPlan`**: reuses the shared `modifyPlanWOVersion` generic to mark the plain attr Unknown on version change, so Terraform accepts the new sensitive value from Apply instead of rejecting "inconsistent values for sensitive".
- `NodeResource` now implements `ResourceWithModifyPlan`.

## Tests
- `resolveNodeSecretsWO` {Create, NoWOConfigured}
- `resolveNodeSecretsWOUpdate` {TriggerBumped, FirstUse, NoTrigger}
- `TestNodeResource_Create_WithWriteOnlyToken`: full Create path supplying the secret only via `api_token_wo`; asserts the resolved value reaches the panel form (`apiToken=wo-create-secret`).
- `ModifyPlan` itself is **not** directly unit-tested — same as the existing settings resources (`panel_general`/`panel_security`/`panel_telegram`/`panel_email` all show ModifyPlan at 0% in unit coverage). It's exercised end-to-end by acc-tests; the core logic lives in the shared `modifyPlanWOVersion` (already covered by settings) plus the resolve helpers (covered above).

## Checks
- `go vet ./...`, `golangci-lint run ./provider/` (0 issues), `go build ./...` — green.
- `go test ./provider/` — green. Coverage: `resolveNodeSecretsWO` 100%, `resolveNodeSecretsWOUpdate` 75% (the no-`_wo`-value branch).
- Pre-commit (fmt/vet/lint/build/markdownlint) green.

## Docs
- `docs/resources/node.md`: added `_wo`/`_wo_version` argument rows for both secrets; replaced the "M4 is pending" scope note with the write-only explanation.
- `SECURITY.md`: node row now lists the `_wo` variants.
- `AGENTS.md`: added `threexui_node` to the "Write-only secret attributes" table; updated the node section to mention the write-only strategy.

## Non-goals
- Acc-tests for the write-only rotation lifecycle remain deferred (no second-panel test harness — same as M2/M3). The Create-with-`_wo` unit test covers the resolve+send path; the ModifyPlan rotation is the same generic as the settings resources.

Closes #319 — completes milestone #4.
