### PR TITLE
fix: audit easy-wins — hysteria drift, auth Sensitive, SECURITY.md, AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Five resources — `panel_general`, `panel_security`, `panel_telegram`,
 
 ### Write-only secret attributes (Terraform 1.11+ / OpenTofu 1.11+)
 
-Four singleton secrets have write-only (`_wo`) alternatives following the AWS/Azure pattern.
+Five singleton secrets have write-only (`_wo`) alternatives following the AWS/Azure pattern.
 Each secret gets three attributes: old `Sensitive` attr + `WriteOnly` attr + `_wo_version` trigger.
 
 | Resource | Old attr | Write-only | Version trigger |
@@ -155,7 +155,7 @@ has its own `*_schema.go` file.
 ### Xray version (`resource_xray_version.go`)
 
 Separate resource — singleton with ID `"xray_version"`. Calls `InstallXray` + polls
-`waitForXrayVersion` (90×1s) until the version matches; if the panel still reports a
+`waitForXrayVersion` (180×1s) until the version matches; if the panel still reports a
 stale version after 30 attempts it re-issues `InstallXray` once (3x-ui v3.2.6–v3.2.7
 sometimes silently drop the first install, #262). Read treats `"Unknown"` as a
 soft-fail (Warning + preserved state). Delete is a no-op with a warning (removing
@@ -192,8 +192,10 @@ inbounds first. Import is by numeric id (`ImportStatePassthroughID`). `api_token
 and `pinned_cert_sha256` are `Sensitive` (panel returns them raw, no redaction —
 issue #314 R1) with write-only `_wo` variants following the settings-style
 strategy (`api_token_wo`+`_wo_version`, `pinned_cert_sha256_wo`+`_wo_version`;
-`resolveNodeSecretsWO`/`resolveNodeSecretsWOUpdate` + ModifyPlan via the
-shared `modifyPlanWOVersion` generic). Schema lives in `node_schema.go`;
+`resolveNodeSecretsWO`/`resolveNodeSecretsWOUpdate` + an **inlined** ModifyPlan
+(not the shared `modifyPlanWOVersion` generic — the node has two write-only secrets
+and the generic re-reads/overwrites `resp.Plan` on each call, which would erase the
+first `Unknown` mark on the second). Schema lives in `node_schema.go`;
 the typed `Node` model is shared with the `threexui_nodes` data source (`types.go`).
 
 ### Host group (`resource_host_group.go`)
@@ -205,9 +207,10 @@ list aside, create `POST /add`, read `GET /get/:groupId`, update `POST /update/:
 delete `POST /del/:groupId` — all with a **JSON body** (`entity.HostGroup`), not
 form-POST like inbounds/nodes. Create does `POST /add` (server generates
 `groupId` via `random.NumLower(16)` when omitted), then re-reads `/get/:groupId`
-for canonical state. Read treats a missing group (HTTP 200 + `success:false` with a
-gorm "record not found" message, handled via `isAPIRecordNotFound`) as remove-from-
-state. Update `POST /update/:groupId` (delete-then-recreate under transaction) then
+for canonical state. Read treats a missing group (HTTP 200 + `success:false` with an
+explicit `"host group not found"` message — **not** a gorm record-not-found like
+nodes; detected via the separate `isHostGroupNotFound`, not `isAPIRecordNotFound`) as
+remove-from-state. Update `POST /update/:groupId` (delete-then-recreate under transaction) then
 re-read; delete `POST /del/:groupId`. Import is by `groupId`
 (`ImportStatePassthroughID`). `inbound_ids` is Required (`min=1`), `remark` Required,
 `port` 0–65535, `security`/`mihomo_ip_version` enum-validated. No sensitive fields →
@@ -356,7 +359,7 @@ Imperative mood, concise subjects.
   **v3.2.x**, **v3.3.x**, **v3.4.x**, **v3.5.x** (up to v3.5.0).
 - Flaky test quarantine: `skipOnFlakyVersions(t, ...)` / `skipIfFlaky(t)` with
   `THREEXUI_SKIP_FLAKY` env var to skip known-broken upstream versions.
-- Xray-version acc-tests use `waitForXrayVersion(t, ctx, client)` (90×1s retry on
+- Xray-version acc-tests use `waitForXrayVersion(t, ctx, client)` (180×1s retry on
   `ErrXrayVersionUnknown`) — covers both the cold-start race (handled by the
   `_wait-for-xray` + `_warm-xray-version-cache` Taskfile gates, the latter pre-warms
   3x-ui's 15-min GitHub-API cache) and mid-test restarts after `TestAccXray*`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,8 @@ Starting with provider v3.13.0, resources that manage secrets offer write-only (
 | `threexui_panel_security` | `two_factor_token_wo` | `two_factor_token_wo_version` |
 | `threexui_panel_telegram` | `tg_bot_token_wo` | `tg_bot_token_wo_version` |
 | `threexui_panel_general` | `ldap_password_wo` | `ldap_password_wo_version` |
+| `threexui_panel_email` | `smtp_password_wo` | `smtp_password_wo_version` |
+| `threexui_node` | `api_token_wo`, `pinned_cert_sha256_wo` | `api_token_wo_version`, `pinned_cert_sha256_wo_version` |
 
 ### How it works
 

--- a/docs/resources/inbound_client.md
+++ b/docs/resources/inbound_client.md
@@ -78,7 +78,7 @@ resource "threexui_inbound_client" "hysteria_user" {
 - `password` (Optional, String, Sensitive) - Client password (used by trojan/shadowsocks).
 - `flow` (Optional, String) - Flow control (e.g. `xtls-rprx-vision`).
 - `reverse_tag` (Optional, String) - VLESS reverse tag. Stored in 3x-ui as `reverse.tag` and available on 3x-ui v2.9.4+.
-- `auth` (Optional, String) - Auth password for Hysteria clients. Used as client identifier instead of UUID.
+- `auth` (Optional, String, Sensitive) - Auth password for Hysteria clients. Used as client identifier instead of UUID.
 - `limit_ip` (Optional, Number) - Maximum concurrent connections.
 - `total_gb` (Optional, Number) - Traffic limit in GB.
 - `expiry_time` (Optional, Number) - Expiry time as Unix timestamp in milliseconds.

--- a/provider/resource_inbound_client.go
+++ b/provider/resource_inbound_client.go
@@ -142,6 +142,7 @@ func (r *InboundClientResource) Schema(_ context.Context, _ resource.SchemaReque
 			"auth": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
+				Sensitive:   true,
 				Description: "Auth password for Hysteria clients.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),

--- a/provider/stream_settings.go
+++ b/provider/stream_settings.go
@@ -136,7 +136,7 @@ func flattenStreamSettings(stream string) ([]any, error) {
 		}
 	}
 	if v, ok := payload["hysteriaSettings"].(map[string]any); ok {
-		if h := flattenHysteriaStreamSettings(v); len(h) > 0 || network == "hysteria2" {
+		if h := flattenHysteriaStreamSettings(v); len(h) > 0 || network == "hysteria" {
 			out["hysteria_settings"] = []any{h}
 		}
 	}

--- a/provider/stream_settings_test.go
+++ b/provider/stream_settings_test.go
@@ -350,3 +350,23 @@ func TestKCPSettings_Roundtrip(t *testing.T) {
 		t.Fatalf("expected max_sending_window=128 after roundtrip, got %v", kcp["max_sending_window"])
 	}
 }
+
+// TestFlattenStreamSettings_HysteriaEmptySettingsRetained is a regression test
+// for #341: when network="hysteria" and hysteriaSettings is an empty object
+// (all defaults), the hysteria_settings block must still be retained — otherwise
+// the resource shows perpetual drift (plan re-adds an empty block, refresh drops
+// it again). Previously the fallback compared network to the wrong value
+// ("hysteria2", a v3.0.2/v3.1.0-only protocol name) instead of "hysteria".
+func TestFlattenStreamSettings_HysteriaEmptySettingsRetained(t *testing.T) {
+	out, err := flattenStreamSettings(`{"network":"hysteria","hysteriaSettings":{}}`)
+	if err != nil {
+		t.Fatalf("flattenStreamSettings error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty result")
+	}
+	first := out[0].(map[string]any)
+	if _, ok := first["hysteria_settings"]; !ok {
+		t.Fatalf("hysteria_settings must be retained for network=hysteria even when empty, got: %#v", first)
+	}
+}

--- a/provider/unit_plan_test.go
+++ b/provider/unit_plan_test.go
@@ -229,7 +229,7 @@ func TestEmptyNetworkSettingsRoundtrip(t *testing.T) {
 		{"httpupgrade", "httpupgrade", "httpupgrade_settings", "httpupgradeSettings"},
 		{"xhttp", "xhttp", "xhttp_settings", "xhttpSettings"},
 		{"kcp", "kcp", "kcp_settings", "kcpSettings"},
-		{"hysteria_stream", "hysteria2", "hysteria_settings", "hysteriaSettings"},
+		{"hysteria_stream", "hysteria", "hysteria_settings", "hysteriaSettings"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
fix: audit easy-wins — hysteria drift, auth Sensitive, SECURITY.md, AGENTS.md

Bundles several low-risk findings from the consistency audit into one PR.

#341 — hysteria_settings dropped on Read when network=hysteria (perpetual drift)
flattenStreamSettings compared the fallback network name to "hysteria2" (a
v3.0.2/v3.1.0-only protocol name) instead of "hysteria" (the actual stream
network name, the only value networkValidators accepts). For a hysteria
inbound with default (empty) hysteria_settings, the block was dropped from
state on every refresh → perpetual plan drift. Fix: compare to "hysteria".
Regression test: TestFlattenStreamSettings_HysteriaEmptySettingsRetained.
unit_plan_test.go's TestEmptyNetworkSettingsRoundtrip used the wrong value
("hysteria2") and is corrected to "hysteria".

#344 (partial) — auth missing Sensitive; SECURITY.md WO table stale
threexui_inbound_client.auth ("Auth password for Hysteria clients") was not
marked Sensitive even though SECURITY.md lists it as sensitive and the
sibling password/secret attrs are Sensitive. Add Sensitive: true + docs label.
SECURITY.md write-only table was missing threexui_panel_email (smtp_password_wo)
and threexui_node (api_token_wo, pinned_cert_sha256_wo) — both exist in code.

#340 — AGENTS.md inaccuracies vs current code
- waitForXrayVersion budget "90×1s" → "180×1s" (two locations; code is 180).
- "Four singleton secrets" → "Five" (ldap_password_wo added in v3.4.2 delta).
- Node ModifyPlan is inlined (not the shared modifyPlanWOVersion generic)
  because the node has two write-only secrets.
- Host-group not-found detection uses the separate isHostGroupNotFound
  ("host group not found" sentinel), not isAPIRecordNotFound/gorm.

Refs #341, #344, #340 (partial). Full docs-drift backfill (#344) and the
remaining audit items (#343 race, #345 coverage, #346 dead code, #347 WO)
tracked separately.
