### PR TITLE
docs: mention finalmask xmc type + add sub_updates range validator

### DIFF
--- a/provider/resource_settings_tabs.go
+++ b/provider/resource_settings_tabs.go
@@ -580,7 +580,8 @@ func panelSubscriptionSchema() schema.Schema {
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"sub_updates": schema.Int64Attribute{
-				Optional: true, Computed: true,
+				Optional:   true, Computed: true,
+				Validators: subUpdatesValidators(),
 				PlanModifiers: []planmodifier.Int64{int64planmodifier.UseStateForUnknown()},
 			},
 			"sub_encrypt": schema.BoolAttribute{
@@ -672,7 +673,7 @@ func panelSubscriptionSchema() schema.Schema {
 			"sub_json_final_mask": schema.StringAttribute{
 				Optional:      true,
 				Computed:      true,
-				Description:   "JSON subscription global finalmask — tcp/udp masks and quicParams (3x-ui v3.2.8+).",
+				Description:   "JSON subscription global finalmask — TCP mask type (fragment/sudoku/header-custom/xmc), UDP masks and quicParams (3x-ui v3.2.8+; xmc added in v3.5.0).",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"sub_theme_dir": schema.StringAttribute{

--- a/provider/validators.go
+++ b/provider/validators.go
@@ -48,6 +48,14 @@ func maxRetriesValidators() []validator.Int64 {
 	}
 }
 
+// subUpdatesValidators validates the sub_updates range (0–525600, i.e. up to one year in minutes).
+// The panel widened this from min(1).max(168) to min(0).max(525600) in 3x-ui v3.5.0.
+func subUpdatesValidators() []validator.Int64 {
+	return []validator.Int64{
+		int64validator.Between(0, 525600),
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Inbound resource validators
 // ---------------------------------------------------------------------------

--- a/provider/validators_test.go
+++ b/provider/validators_test.go
@@ -127,6 +127,27 @@ func TestMaxRetriesValidators(t *testing.T) {
 	}
 }
 
+func TestSubUpdatesValidators(t *testing.T) {
+	v := subUpdatesValidators()
+	valid := []int64{0, 1, 168, 525600}
+	for _, val := range valid {
+		for _, vv := range v {
+			if testInt64Validator(t, vv, val) {
+				t.Errorf("subUpdatesValidators should accept %d", val)
+			}
+		}
+	}
+
+	invalid := []int64{-1, 525601}
+	for _, val := range invalid {
+		for _, vv := range v {
+			if !testInt64Validator(t, vv, val) {
+				t.Errorf("subUpdatesValidators should reject %d", val)
+			}
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Inbound resource validators
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #339

Two minor doc/validator gaps:

1. **finalmask `xmc` type**: Updated `sub_json_final_mask` Description to mention `xmc` alongside existing mask types (fragment/sudoku/header-custom). Added in 3x-ui v3.5.0.

2. **sub_updates range validator**: Added `int64validator.Between(0, 525600)` — the panel widened this from min(1).max(168) to min(0).max(525600) in v3.5.0. Catches typos early and documents the contract.

- New `subUpdatesValidators()` helper in `validators.go`
- Unit test `TestSubUpdatesValidators` (accepts 0, 1, 168, 525600; rejects -1, 525601)