### PR TITLE
chore: remove dead code (RestartPanel), merge duplicate expandIntList/flattenIntList

### DIFF
--- a/provider/client.go
+++ b/provider/client.go
@@ -1148,14 +1148,6 @@ func (c *Client) SendRestart(ctx context.Context) error {
 	return nil
 }
 
-// RestartPanel sends a restart and waits for the panel to become ready.
-func (c *Client) RestartPanel(ctx context.Context) error {
-	if err := c.SendRestart(ctx); err != nil {
-		return err
-	}
-	return c.WaitForReady(ctx)
-}
-
 // RestartXrayService restarts the Xray core via the 3x-ui API.
 func (c *Client) RestartXrayService(ctx context.Context) error {
 	return c.doJSON(ctx, http.MethodPost, "panel/api/server/restartXrayService", nil, nil)

--- a/provider/settings.go
+++ b/provider/settings.go
@@ -29,7 +29,7 @@ func buildSettingsJSON(item map[string]any, protocol string) string {
 	if v, ok := item["testseed"]; ok {
 		switch ts := v.(type) {
 		case []any:
-			payload["testseed"] = expandIntList(ts)
+			payload["testseed"] = flattenIntList(ts)
 		case []int:
 			payload["testseed"] = ts
 		}
@@ -456,14 +456,6 @@ func flattenStringMap(in map[string]any) map[string]string {
 		if s, ok := v.(string); ok {
 			out[k] = s
 		}
-	}
-	return out
-}
-
-func expandIntList(list []any) []int {
-	out := make([]int, 0, len(list))
-	for _, v := range list {
-		out = append(out, intValue(v))
 	}
 	return out
 }

--- a/provider/xray_outbound_dns.go
+++ b/provider/xray_outbound_dns.go
@@ -154,7 +154,7 @@ func expandOutboundDNSSettings(m map[string]any) map[string]any {
 		out["nonIPQuery"] = v
 	}
 	if v, ok := item["block_types"].([]any); ok && len(v) > 0 {
-		out["blockTypes"] = expandIntList(v)
+		out["blockTypes"] = flattenIntList(v)
 	}
 	if len(out) == 0 {
 		return nil

--- a/provider/xray_outbound_wireguard.go
+++ b/provider/xray_outbound_wireguard.go
@@ -303,7 +303,7 @@ func expandWireguardOutSettings(m map[string]any) map[string]any {
 		out["domainStrategy"] = v
 	}
 	if v, ok := item["reserved"].([]any); ok && len(v) > 0 {
-		out["reserved"] = expandIntList(v)
+		out["reserved"] = flattenIntList(v)
 	}
 	if v, ok := item["no_kernel_tun"].(bool); ok {
 		out["noKernelTun"] = v


### PR DESCRIPTION
Closes #346 (partial — dead code + duplicates)

**Removed:**
- `Client.RestartPanel` — 0 callers, dead code. Production uses `SendRestart` + `WaitForReady` separately.

**Merged:**
- `expandIntList` and `flattenIntList` were byte-identical — deleted `expandIntList`, updated 3 callsites to use `flattenIntList`.

**Deferred** (needs more careful refactoring):
- `stringValue`/`intValue`/`boolValue` relocation to shared helper file
- `test_helpers.go` → `_test.go` rename (requires merging package declarations with existing `test_helpers_test.go`)