### PR TITLE
fix: add defensive hysteria2 back-compat for hysteria_settings retention

### DIFF
--- a/provider/stream_settings.go
+++ b/provider/stream_settings.go
@@ -136,7 +136,7 @@ func flattenStreamSettings(stream string) ([]any, error) {
 		}
 	}
 	if v, ok := payload["hysteriaSettings"].(map[string]any); ok {
-		if h := flattenHysteriaStreamSettings(v); len(h) > 0 || network == "hysteria" {
+		if h := flattenHysteriaStreamSettings(v); len(h) > 0 || network == "hysteria" || network == "hysteria2" {
 			out["hysteria_settings"] = []any{h}
 		}
 	}

--- a/provider/stream_settings_test.go
+++ b/provider/stream_settings_test.go
@@ -357,16 +357,22 @@ func TestKCPSettings_Roundtrip(t *testing.T) {
 // the resource shows perpetual drift (plan re-adds an empty block, refresh drops
 // it again). Previously the fallback compared network to the wrong value
 // ("hysteria2", a v3.0.2/v3.1.0-only protocol name) instead of "hysteria".
+// The defensive `hysteria2` fallback is also tested for backward compatibility.
 func TestFlattenStreamSettings_HysteriaEmptySettingsRetained(t *testing.T) {
-	out, err := flattenStreamSettings(`{"network":"hysteria","hysteriaSettings":{}}`)
-	if err != nil {
-		t.Fatalf("flattenStreamSettings error: %v", err)
-	}
-	if len(out) == 0 {
-		t.Fatal("expected non-empty result")
-	}
-	first := out[0].(map[string]any)
-	if _, ok := first["hysteria_settings"]; !ok {
-		t.Fatalf("hysteria_settings must be retained for network=hysteria even when empty, got: %#v", first)
+	for _, network := range []string{"hysteria", "hysteria2"} {
+		t.Run(network, func(t *testing.T) {
+			json := `{"network":"` + network + `","hysteriaSettings":{}}`
+			out, err := flattenStreamSettings(json)
+			if err != nil {
+				t.Fatalf("flattenStreamSettings error: %v", err)
+			}
+			if len(out) == 0 {
+				t.Fatal("expected non-empty result")
+			}
+			first := out[0].(map[string]any)
+			if _, ok := first["hysteria_settings"]; !ok {
+				t.Fatalf("hysteria_settings must be retained for network=%s even when empty, got: %#v", network, first)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #341

The core fix (hysteria2 → hysteria) was already applied in PR #350, but lacked the defensive `hysteria2` back-compat for older panel versions.

This PR:
- Changes fallback to `network == "hysteria" || network == "hysteria2"` for defensive backward compatibility
- Extends the unit test to cover both `hysteria` and `hysteria2` network values in table-driven subtests