### PR TITLE
fix: backfill missing attrs in docs, add Deprecated/Sensitive labels

### DIFF
--- a/docs/resources/host_group.md
+++ b/docs/resources/host_group.md
@@ -65,6 +65,7 @@ terraform import threexui_host_group.premium_eu 1234567890123456
 - `mihomo_x25519` (Optional, Boolean) - Use Mihomo X25519 key exchange.
 - `shuffle_host` (Optional, Boolean) - Shuffle the host order in generated links.
 - `hosts` (Optional, List of String) - Explicit host list for this group.
+- `tags` (Optional, List of String) - Tags assigned to this host group.
 
 ## Attribute Reference
 

--- a/docs/resources/inbound.md
+++ b/docs/resources/inbound.md
@@ -164,7 +164,7 @@ resource "threexui_inbound" "hysteria" {
 ### Top-level
 
 - `port` (Required, Number) - Port number for the inbound.
-- `protocol` (Required, String) - Protocol type (`vless`, `vmess`, `trojan`, `shadowsocks`, `http`, `mixed`, `wireguard`, `tunnel`, `hysteria`). Legacy `socks` and `dokodemo-door` are available only on panels before 3x-ui v3.2.0; use `mixed` and `tunnel` on v3.2.0+.
+- `protocol` (Required, String) - Protocol type (`vless`, `vmess`, `trojan`, `shadowsocks`, `http`, `mixed`, `wireguard`, `tunnel`, `hysteria`). Legacy `socks` and `dokodemo-door` are available only on panels before 3x-ui v3.2.0; use `mixed` and `tunnel` on v3.2.0+. `tun` is also available on 3x-ui v3.5.0+.
 - `enable` (Optional, Boolean) - Whether the inbound is enabled. Default is `true`.
 - `remark` (Optional, String) - A label/name for the inbound.
 - `listen` (Optional, String) - Listen address.
@@ -175,6 +175,9 @@ resource "threexui_inbound" "hysteria" {
 - `traffic_reset` (Optional, String) - Traffic reset period. Default is `never`.
 - `node_id` (Optional, Number) - 3x-ui v3 node ID for multi-node deployments. Leave unset for the local panel. Changing this value recreates the inbound because 3x-ui v3 does not support moving an existing inbound between nodes.
 - `restart_xray` (Optional, Boolean) - Restart Xray core after create, update, or delete operations. Default is `false`.
+- `sub_sort_index` (Optional, Number) - 1-based sort order of this inbound's links in subscription output (lower first; ties by id). Added in 3x-ui v3.3.1; ignored by older panels.
+- `share_addr` (Optional, String) - Share address used in generated subscription links when share_addr_strategy is custom. Added in 3x-ui v3.3.1; ignored by older panels.
+- `share_addr_strategy` (Optional, String) - Strategy for the share address in subscription links: `node` (inbound listen/node address), `listen`, or `custom` (uses `share_addr`). Added in 3x-ui v3.3.1; ignored by older panels.
 
 ### Per-protocol Settings Blocks
 
@@ -199,7 +202,7 @@ Use the block matching your `protocol`. Only one should be specified.
 #### `shadowsocks_settings`
 
 - `method` (Optional, String) - Encryption method (e.g. `chacha20-ietf-poly1305`, `2022-blake3-aes-256-gcm`). On 3x-ui v2.9.3+ the legacy `aes-128-gcm`/`aes-256-gcm` ciphers were dropped from the xray user switch and silently route through Shadowsocks-2022; pick a chacha20 variant or a `2022-blake3-*` method to stay compatible across the matrix.
-- `password` (Optional, String) - Password.
+- `password` (Optional, String, Sensitive) - Password.
 - `network` (Optional, String) - Network type (e.g. `tcp,udp`).
 - `iv_check` (Optional, Boolean) - Enable IV check.
 
@@ -218,17 +221,26 @@ Use the block matching your `protocol`. Only one should be specified.
 - `ip` (Optional, String) - IP address.
 - `account` (Optional, Block List) - Same structure as http account.
 
+#### `mixed_settings`
+
+Settings for mixed (HTTP+SOCKS) proxy protocol.
+
+- `auth` (Optional, String) - Authentication type (e.g. `password`, `noauth`).
+- `udp` (Optional, Boolean) - Enable UDP support.
+- `ip` (Optional, String) - IP address for UDP.
+- `account` (Optional, Block List) - Authentication accounts. Same structure as http account.
+
 #### `wireguard_settings`
 
 - `mtu` (Optional, List of Number) - MTU values `[IPv4, IPv6]`.
-- `secret_key` (Optional, String) - Secret key.
+- `secret_key` (Optional, String, Sensitive) - Secret key.
 - `no_kernel_tun` (Optional, Boolean) - Disable kernel TUN.
 - `gateway` (Optional, List of String) - Gateway addresses.
 - `dns` (Optional, List of String) - DNS server addresses.
 - `peer` (Optional, Block List) - WireGuard peers.
-  - `private_key` (Optional, String)
+  - `private_key` (Optional, String, Sensitive)
   - `public_key` (Optional, String)
-  - `pre_shared_key` (Optional, String)
+  - `pre_shared_key` (Optional, String, Sensitive)
   - `allowed_ips` (Optional, List of String)
   - `keep_alive` (Optional, Number)
 - `clients` (Optional, Block List) - WireGuard multi-client peers (3x-ui v3.4.2+). Absent/empty on older panels. Each entry is one client device the server accepts, with its own keypair and traffic limits. Use EITHER `clients` OR the legacy `peer` for an inbound, not both — the panel treats them as separate models and populating both yields undefined behavior.
@@ -289,6 +301,12 @@ Used for both `tunnel` and `dokodemo-door` protocols.
   - `mode` (Optional, String)
   - `no_sse_header` (Optional, Boolean)
   - `keep_alive_interval` (Optional, Number)
+  - `x_padding_bytes` (Optional, String) - xPadding bytes range (e.g. `100-1000`).
+  - `x_padding_obfs_mode` (Optional, Boolean) - Enable xPadding obfuscation mode.
+  - `x_padding_key` (Optional, String) - xPadding encryption key.
+  - `x_padding_header` (Optional, String) - xPadding header name.
+  - `x_padding_placement` (Optional, String) - xPadding placement (e.g. `header`, `body`).
+  - `x_padding_method` (Optional, String) - xPadding method (e.g. `aes`).
 - `kcp_settings` (Optional, Block) - mKCP settings.
   - `mtu` (Optional, Number)
   - `tti` (Optional, Number)
@@ -307,7 +325,7 @@ Used for both `tunnel` and `dokodemo-door` protocols.
   - `xver` (Optional, Number)
   - `target` (Optional, String)
   - `server_names` (Optional, List of String)
-  - `private_key` (Optional, String) - Auto-generated if not specified.
+  - `private_key` (Optional, String, Sensitive) - Auto-generated if not specified.
   - `short_ids` (Optional, List of String) - Auto-generated if not specified.
   - `mldsa65_seed` (Optional, String)
   - `settings` (Optional, Attribute) - Reality inner settings (client-side). Auto-populated if omitted.

--- a/docs/resources/panel_general.md
+++ b/docs/resources/panel_general.md
@@ -36,11 +36,12 @@ resource "threexui_panel_general" "settings" {
 - `web_key_file` (Optional, String) - TLS key file path. Default is `""`.
 - `session_max_age` (Optional, Number) - Session max age in minutes. Default is `360`.
 - `trusted_proxy_cidrs` (Optional, String) - Comma-separated trusted reverse proxy IPs/CIDRs used for forwarded headers. Default is `127.0.0.1/32,::1/128` on 3x-ui v3.0.2+.
+- `warp_update_interval` (Optional, Number) - Interval (hours) between Cloudflare WARP / geo auto-updates via Xray-core (0 disables). Added in 3x-ui v3.3.0; ignored by older panels.
 
 ### Display
 
 - `page_size` (Optional, Number) - Items per page. Default is `25`.
-- `remark_model` (Optional, String) - Remark display model. Default is `-ieo`.
+- `remark_model` (Optional, String, Deprecated) - Remark display model. Default is `-ieo`. **Deprecated:** Removed from 3x-ui v3.4.0 (superseded by `remark_template`). Use `remark_template` on v3.4.0+; accepted but has no effect on v3.4.0+ panels.
 - `date_picker` (Optional, String) - Date picker type. Default is `gregorian`.
 - `time_location` (Optional, String) - Timezone. Default is `Local`.
 - `expire_diff` (Optional, Number) - Expiry diff threshold. Default is `0`.

--- a/docs/resources/panel_subscription.md
+++ b/docs/resources/panel_subscription.md
@@ -71,8 +71,11 @@ resource "threexui_panel_subscription" "settings" {
 - `sub_key_file` (Optional, String) - TLS key file path.
 - `sub_updates` (Optional, Number) - Update interval in hours.
 - `sub_encrypt` (Optional, Boolean) - Encrypt subscription data.
-- `sub_show_info` (Optional, Boolean) - Show info in subscription.
-- `sub_email_in_remark` (Optional, Boolean) - Include the client email in subscription profile names. Default is `true` on 3x-ui v3.0.2+.
+- `sub_show_info` (Optional, Boolean, Deprecated) - Show info in subscription. **Deprecated:** Removed from 3x-ui v3.4.0; accepted but has no effect on v3.4.0+ panels.
+- `sub_email_in_remark` (Optional, Boolean, Deprecated) - Include the client email in subscription profile names. Default is `true` on 3x-ui v3.0.2+. **Deprecated:** Removed from 3x-ui v3.4.0; accepted but has no effect on v3.4.0+ panels.
+- `sub_theme_dir` (Optional, String) - Absolute path to a folder containing a custom subscription page template. Added in 3x-ui v3.3.0; ignored by older panels.
+- `remark_template` (Optional, String) - Subscription remark template (`{{VAR}}` tokens rendered per client, e.g. Jalali date/transport/status). Added in 3x-ui v3.4.0; ignored by older panels.
+- `sub_hide_settings` (Optional, Boolean) - Hide server settings in happ subscription (Happ only). Added in 3x-ui v3.4.0; ignored by older panels.
 
 ### URI
 

--- a/docs/resources/panel_telegram.md
+++ b/docs/resources/panel_telegram.md
@@ -37,8 +37,10 @@ resource "threexui_panel_telegram" "settings" {
 - `tg_lang` (Optional, String) - Telegram bot language.
 - `tg_run_time` (Optional, String) - Cron expression for periodic reports.
 - `tg_bot_backup` (Optional, Boolean) - Enable periodic backup via Telegram.
-- `tg_bot_login_notify` (Optional, Boolean) - Enable login notifications via Telegram.
+- `tg_bot_login_notify` (Optional, Boolean, Deprecated) - Enable login notifications via Telegram. **Deprecated:** Removed from 3x-ui v3.4.0; accepted but has no effect on v3.4.0+ panels.
 - `tg_cpu` (Optional, Number) - CPU usage threshold for alerts (percentage).
+- `tg_enabled_events` (Optional, String) - Comma-separated event types to send via Telegram (e.g. login, backup, traffic threshold). Added in 3x-ui v3.4.0; ignored by older panels.
+- `tg_memory` (Optional, Number) - Memory usage threshold (%) for Telegram alerts (0-100). Added in 3x-ui v3.4.0; ignored by older panels.
 
 ## Attribute Reference
 

--- a/docs/resources/xray_dns.md
+++ b/docs/resources/xray_dns.md
@@ -52,6 +52,8 @@ resource "threexui_xray_dns" "config" {
 - `disable_fallback` (Bool, Optional) - Disable DNS fallback.
 - `disable_fallback_if_match` (Bool, Optional) - Disable fallback if match found.
 - `client_ip` (String, Optional) - Client IP for EDNS.
+- `enable_parallel_query` (Bool, Optional) - Enable parallel DNS query across all configured servers.
+- `use_system_hosts` (Bool, Optional) - Use system hosts file for DNS resolution.
 - `hosts` (Map of String, Optional) - Static DNS host mappings.
 
 ### server (Block, Optional, List)


### PR DESCRIPTION
Closes #344

Backfills 22 undocumented attributes across 6 docs files, adds Deprecated/Sensitive labels.

All code fixes (`auth` Sensitive, SECURITY.md WO table) were already in main (PR #350). This PR is purely docs.

**Changes by file:**

- **host_group.md** — added `tags`
- **panel_telegram.md** — added `tg_enabled_events`, `tg_memory`; marked `tg_bot_login_notify` Deprecated
- **panel_subscription.md** — added `sub_theme_dir`, `remark_template`, `sub_hide_settings`; marked `sub_show_info`, `sub_email_in_remark` Deprecated
- **panel_general.md** — added `warp_update_interval`; marked `remark_model` Deprecated
- **inbound.md** — added `sub_sort_index`, `share_addr`, `share_addr_strategy`, `mixed_settings` block, 6× `x_padding_*`; added `tun` to protocol list; Sensitive labels for `shadowsocks_settings.password`, `wireguard_settings.secret_key`, `reality_settings.private_key`, wireguard `peer.private_key` / `peer.pre_shared_key`
- **xray_dns.md** — added `enable_parallel_query`, `use_system_hosts`