### PR TITLE
test: add unit tests for ~60 expand/flatten functions

### DIFF
--- a/provider/client_helpers_test.go
+++ b/provider/client_helpers_test.go
@@ -1,0 +1,181 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Tests for Client.GetNewX25519Cert and Client.GetNewVlessEnc via httptest.
+// ---------------------------------------------------------------------------
+
+func TestGetNewX25519Cert_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/panel/api/server/getNewX25519Cert" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		certObj := map[string]any{
+			"privateKey": "priv-xyz",
+			"publicKey":  "pub-xyz",
+		}
+		w.Write(okResponse(certObj))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	result, err := client.GetNewX25519Cert(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["privateKey"] != "priv-xyz" {
+		t.Fatalf("unexpected privateKey: %v", result["privateKey"])
+	}
+	if result["publicKey"] != "pub-xyz" {
+		t.Fatalf("unexpected publicKey: %v", result["publicKey"])
+	}
+}
+
+func TestGetNewX25519Cert_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(failResponse("internal error"))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	_, err := client.GetNewX25519Cert(context.Background())
+	if err == nil {
+		t.Fatal("expected error for API failure")
+	}
+}
+
+func TestGetNewX25519Cert_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return completely invalid JSON body (not wrapped in apiResponse)
+		w.Write([]byte(`not-json-at-all`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	_, err := client.GetNewX25519Cert(context.Background())
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestGetNewVlessEnc_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/panel/api/server/getNewVlessEnc" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		authsObj := map[string]any{
+			"auths": []any{
+				map[string]any{
+					"label":      "label1",
+					"decryption": "none",
+					"encryption": "none",
+				},
+				map[string]any{
+					"label":      "label2",
+					"decryption": "none",
+					"encryption": "aes-128-gcm",
+				},
+			},
+		}
+		w.Write(okResponse(authsObj))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	auths, err := client.GetNewVlessEnc(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths, got %d", len(auths))
+	}
+	if auths[0].Label != "label1" {
+		t.Fatalf("unexpected label[0]: %v", auths[0].Label)
+	}
+	if auths[0].Encryption != "none" {
+		t.Fatalf("unexpected encryption[0]: %v", auths[0].Encryption)
+	}
+	if auths[1].Label != "label2" {
+		t.Fatalf("unexpected label[1]: %v", auths[1].Label)
+	}
+	if auths[1].Encryption != "aes-128-gcm" {
+		t.Fatalf("unexpected encryption[1]: %v", auths[1].Encryption)
+	}
+}
+
+func TestGetNewVlessEnc_Empty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authsObj := map[string]any{
+			"auths": []any{},
+		}
+		w.Write(okResponse(authsObj))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	auths, err := client.GetNewVlessEnc(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 0 {
+		t.Fatalf("expected 0 auths, got %d", len(auths))
+	}
+}
+
+func TestGetNewVlessEnc_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(failResponse("denied"))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	_, err := client.GetNewVlessEnc(context.Background())
+	if err == nil {
+		t.Fatal("expected error for API failure")
+	}
+}
+
+func TestGetNewVlessEnc_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return completely invalid JSON body
+		w.Write([]byte(`not-json-at-all`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	_, err := client.GetNewVlessEnc(context.Background())
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestVlessEncAuth_JSONRoundTrip(t *testing.T) {
+	// Verify the struct unmarshals correctly from real 3x-ui JSON.
+	raw := `[{"label":"l1","decryption":"none","encryption":"none"},{"label":"l2","decryption":"none","encryption":"xchacha20"}]`
+	var auths []VlessEncAuth
+	if err := json.Unmarshal([]byte(raw), &auths); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths, got %d", len(auths))
+	}
+	if auths[0].Label != "l1" || auths[1].Encryption != "xchacha20" {
+		t.Fatalf("unexpected values: %+v", auths)
+	}
+}

--- a/provider/inbound_settings_expand_flatten_test.go
+++ b/provider/inbound_settings_expand_flatten_test.go
@@ -1,0 +1,568 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Table-driven round-trip tests for inbound per-protocol settings expand/flatten.
+// Each case sets fields on the typed model, calls expand*InboundSettings to
+// get an untyped map, then calls flatten*InboundSettings to get the model back,
+// and asserts the relevant fields survive the round-trip.
+//
+// When all model fields are null, expand produces an empty map and flatten
+// returns nil (this is the design). Those cases are marked expectNilFlat.
+// ---------------------------------------------------------------------------
+
+func TestExpandFlatten_VlessSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name          string
+		model         *InboundVlessSettingsModel
+		expectNilFlat bool
+	}{
+		{
+			name: "full",
+			model: &InboundVlessSettingsModel{
+				Decryption:   types.StringValue("none"),
+				Encryption:   types.StringValue("none"),
+				SelectedAuth: types.StringValue("none"),
+				Fallback: []InboundFallbackModel{
+					{Name: types.StringValue("fb1"), Alpn: types.StringValue("h2"), Path: types.StringValue("/ws"), Dest: types.StringValue("127.0.0.1:8080"), Xver: types.Int64Value(1)},
+				},
+			},
+		},
+		{
+			name: "nil_fields",
+			model: &InboundVlessSettingsModel{
+				Decryption: types.StringNull(),
+				Encryption: types.StringNull(),
+			},
+			expectNilFlat: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandVlessInboundSettings(tc.model)
+			if expanded == nil {
+				t.Fatal("expected non-nil expanded map")
+			}
+			flat := flattenVlessInboundSettings(expanded)
+			if tc.expectNilFlat {
+				if flat != nil {
+					t.Fatalf("expected nil flat for empty expand, got %v", flat)
+				}
+				return
+			}
+			if flat == nil {
+				t.Fatal("expected non-nil flattened model")
+			}
+			if flat.Decryption.ValueString() != tc.model.Decryption.ValueString() {
+				t.Fatalf("decryption mismatch: got %q want %q", flat.Decryption.ValueString(), tc.model.Decryption.ValueString())
+			}
+			if len(tc.model.Fallback) > 0 {
+				reExpanded := expandVlessInboundSettings(flat)
+				fbs, ok := reExpanded["fallbacks"].([]any)
+				if !ok {
+					t.Fatal("expected fallbacks slice in re-expanded")
+				}
+				if len(fbs) != len(tc.model.Fallback) {
+					t.Fatalf("fallback count mismatch: got %d want %d", len(fbs), len(tc.model.Fallback))
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_VlessSettings_NilModel(t *testing.T) {
+	if got := expandVlessInboundSettings(nil); got != nil {
+		t.Fatalf("expected nil for nil model, got %v", got)
+	}
+}
+
+func TestExpandFlatten_VlessSettings_EmptyData(t *testing.T) {
+	if got := flattenVlessInboundSettings(map[string]any{}); got != nil {
+		t.Fatalf("expected nil for empty data, got %v", got)
+	}
+}
+
+func TestExpandFlatten_TrojanSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name          string
+		model         *InboundTrojanSettingsModel
+		expectNilFlat bool
+	}{
+		{
+			name: "with_fallbacks",
+			model: &InboundTrojanSettingsModel{
+				Fallback: []InboundFallbackModel{
+					{Dest: types.StringValue("127.0.0.1:443"), Xver: types.Int64Value(0)},
+					{Name: types.StringValue("fb2"), Dest: types.StringValue("127.0.0.1:80")},
+				},
+			},
+		},
+		{
+			name:          "empty",
+			model:         &InboundTrojanSettingsModel{},
+			expectNilFlat: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandTrojanInboundSettings(tc.model)
+			if expanded == nil {
+				t.Fatal("expected non-nil expanded map")
+			}
+			flat := flattenTrojanInboundSettings(expanded)
+			if tc.expectNilFlat {
+				if flat != nil {
+					t.Fatalf("expected nil flat for empty expand, got %v", flat)
+				}
+				return
+			}
+			if flat == nil {
+				t.Fatal("expected non-nil flattened model")
+			}
+			reExpanded := expandTrojanInboundSettings(flat)
+			if len(tc.model.Fallback) > 0 {
+				fbs := reExpanded["fallbacks"].([]any)
+				if len(fbs) != len(tc.model.Fallback) {
+					t.Fatalf("fallback count mismatch: got %d want %d", len(fbs), len(tc.model.Fallback))
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_TrojanSettings_NilModel(t *testing.T) {
+	if got := expandTrojanInboundSettings(nil); got != nil {
+		t.Fatalf("expected nil for nil model, got %v", got)
+	}
+}
+
+func TestExpandFlatten_ShadowsocksSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name          string
+		model         *InboundShadowsocksSettingsModel
+		expectNilFlat bool
+	}{
+		{
+			name: "full",
+			model: &InboundShadowsocksSettingsModel{
+				Method:   types.StringValue("chacha20-ietf-poly1305"),
+				Password: types.StringValue("s3cret"),
+				Network:  types.StringValue("tcp,udp"),
+				IVCheck:  types.BoolValue(true),
+			},
+		},
+		{
+			name: "minimal",
+			model: &InboundShadowsocksSettingsModel{
+				Method: types.StringValue("aes-256-gcm"),
+			},
+		},
+		{
+			name:          "all_null",
+			model:         &InboundShadowsocksSettingsModel{},
+			expectNilFlat: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandShadowsocksInboundSettings(tc.model)
+			if expanded == nil {
+				t.Fatal("expected non-nil expanded map")
+			}
+			flat := flattenShadowsocksInboundSettings(expanded)
+			if tc.expectNilFlat {
+				if flat != nil {
+					t.Fatalf("expected nil flat for empty expand, got %v", flat)
+				}
+				return
+			}
+			if flat == nil {
+				t.Fatal("expected non-nil flattened model")
+			}
+			if flat.Method.ValueString() != tc.model.Method.ValueString() {
+				t.Fatalf("method mismatch: got %q want %q", flat.Method.ValueString(), tc.model.Method.ValueString())
+			}
+			if flat.Password.ValueString() != tc.model.Password.ValueString() {
+				t.Fatalf("password mismatch: got %q want %q", flat.Password.ValueString(), tc.model.Password.ValueString())
+			}
+			if flat.Network.ValueString() != tc.model.Network.ValueString() {
+				t.Fatalf("network mismatch: got %q want %q", flat.Network.ValueString(), tc.model.Network.ValueString())
+			}
+			if flat.IVCheck.ValueBool() != tc.model.IVCheck.ValueBool() {
+				t.Fatalf("iv_check mismatch: got %v want %v", flat.IVCheck.ValueBool(), tc.model.IVCheck.ValueBool())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_ShadowsocksSettings_NilModel(t *testing.T) {
+	if got := expandShadowsocksInboundSettings(nil); got != nil {
+		t.Fatalf("expected nil for nil model, got %v", got)
+	}
+}
+
+func TestExpandFlatten_ShadowsocksSettings_EmptyData(t *testing.T) {
+	if got := flattenShadowsocksInboundSettings(map[string]any{}); got != nil {
+		t.Fatalf("expected nil for empty data, got %v", got)
+	}
+}
+
+func TestExpandFlatten_HTTPSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name          string
+		model         *InboundHTTPSettingsModel
+		expectNilFlat bool
+	}{
+		{
+			name: "full",
+			model: &InboundHTTPSettingsModel{
+				Auth:             types.StringValue("password"),
+				AllowTransparent: types.BoolValue(true),
+				Account: []InboundAccountModel{
+					{User: types.StringValue("u1"), Pass: types.StringValue("p1")},
+					{User: types.StringValue("u2"), Pass: types.StringValue("p2")},
+				},
+			},
+		},
+		{
+			name: "no_accounts",
+			model: &InboundHTTPSettingsModel{
+				Auth:             types.StringValue("noauth"),
+				AllowTransparent: types.BoolValue(false),
+			},
+		},
+		{
+			name:          "all_null",
+			model:         &InboundHTTPSettingsModel{},
+			expectNilFlat: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandHTTPInboundSettings(tc.model)
+			if expanded == nil {
+				t.Fatal("expected non-nil expanded map")
+			}
+			flat := flattenHTTPInboundSettings(expanded)
+			if tc.expectNilFlat {
+				if flat != nil {
+					t.Fatalf("expected nil flat for empty expand, got %v", flat)
+				}
+				return
+			}
+			if flat == nil {
+				t.Fatal("expected non-nil flattened model")
+			}
+			if flat.Auth.ValueString() != tc.model.Auth.ValueString() {
+				t.Fatalf("auth mismatch: got %q want %q", flat.Auth.ValueString(), tc.model.Auth.ValueString())
+			}
+			if flat.AllowTransparent.ValueBool() != tc.model.AllowTransparent.ValueBool() {
+				t.Fatalf("allow_transparent mismatch: got %v want %v", flat.AllowTransparent.ValueBool(), tc.model.AllowTransparent.ValueBool())
+			}
+			if len(tc.model.Account) > 0 {
+				if len(flat.Account) != len(tc.model.Account) {
+					t.Fatalf("account count mismatch: got %d want %d", len(flat.Account), len(tc.model.Account))
+				}
+				for i, acc := range tc.model.Account {
+					if flat.Account[i].User.ValueString() != acc.User.ValueString() {
+						t.Fatalf("account[%d] user mismatch: got %q want %q", i, flat.Account[i].User.ValueString(), acc.User.ValueString())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_HTTPSettings_NilModel(t *testing.T) {
+	if got := expandHTTPInboundSettings(nil); got != nil {
+		t.Fatalf("expected nil for nil model, got %v", got)
+	}
+}
+
+func TestExpandFlatten_SocksSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name          string
+		model         *InboundSocksSettingsModel
+		expectNilFlat bool
+	}{
+		{
+			name: "full",
+			model: &InboundSocksSettingsModel{
+				Auth: types.StringValue("password"),
+				UDP:  types.BoolValue(true),
+				IP:   types.StringValue("127.0.0.1"),
+				Account: []InboundAccountModel{
+					{User: types.StringValue("admin"), Pass: types.StringValue("secret")},
+				},
+			},
+		},
+		{
+			name: "minimal",
+			model: &InboundSocksSettingsModel{
+				UDP: types.BoolValue(false),
+			},
+		},
+		{
+			name:          "all_null",
+			model:         &InboundSocksSettingsModel{},
+			expectNilFlat: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandSocksInboundSettings(tc.model)
+			if expanded == nil {
+				t.Fatal("expected non-nil expanded map")
+			}
+			flat := flattenSocksInboundSettings(expanded)
+			if tc.expectNilFlat {
+				if flat != nil {
+					t.Fatalf("expected nil flat for empty expand, got %v", flat)
+				}
+				return
+			}
+			if flat == nil {
+				t.Fatal("expected non-nil flattened model")
+			}
+			if flat.Auth.ValueString() != tc.model.Auth.ValueString() {
+				t.Fatalf("auth mismatch: got %q want %q", flat.Auth.ValueString(), tc.model.Auth.ValueString())
+			}
+			if flat.UDP.ValueBool() != tc.model.UDP.ValueBool() {
+				t.Fatalf("udp mismatch: got %v want %v", flat.UDP.ValueBool(), tc.model.UDP.ValueBool())
+			}
+			if flat.IP.ValueString() != tc.model.IP.ValueString() {
+				t.Fatalf("ip mismatch: got %q want %q", flat.IP.ValueString(), tc.model.IP.ValueString())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_SocksSettings_NilModel(t *testing.T) {
+	if got := expandSocksInboundSettings(nil); got != nil {
+		t.Fatalf("expected nil for nil model, got %v", got)
+	}
+}
+
+func TestExpandFlatten_HysteriaInboundSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name          string
+		model         *InboundHysteriaSettingsModel
+		expectNilFlat bool
+	}{
+		{
+			name: "version2",
+			model: &InboundHysteriaSettingsModel{
+				Version: types.Int64Value(2),
+			},
+		},
+		{
+			name: "version1",
+			model: &InboundHysteriaSettingsModel{
+				Version: types.Int64Value(1),
+			},
+		},
+		{
+			name:          "null_version",
+			model:         &InboundHysteriaSettingsModel{},
+			expectNilFlat: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandHysteriaInboundSettings(tc.model)
+			if expanded == nil {
+				t.Fatal("expected non-nil expanded map")
+			}
+			flat := flattenHysteriaInboundSettings(expanded)
+			if tc.expectNilFlat {
+				if flat != nil {
+					t.Fatalf("expected nil flat for empty expand, got %v", flat)
+				}
+				return
+			}
+			if flat == nil {
+				t.Fatal("expected non-nil flattened model")
+			}
+			if flat.Version.ValueInt64() != tc.model.Version.ValueInt64() {
+				t.Fatalf("version mismatch: got %d want %d", flat.Version.ValueInt64(), tc.model.Version.ValueInt64())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_HysteriaInboundSettings_NilModel(t *testing.T) {
+	if got := expandHysteriaInboundSettings(nil); got != nil {
+		t.Fatalf("expected nil for nil model, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fallback sub-model expand/flatten
+// ---------------------------------------------------------------------------
+
+func TestExpandFlatten_FallbacksFromModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		list []InboundFallbackModel
+	}{
+		{name: "empty", list: nil},
+		{
+			name: "single",
+			list: []InboundFallbackModel{
+				{Name: types.StringValue("fb"), Alpn: types.StringValue("h2"), Path: types.StringValue("/ws"), Dest: types.StringValue("127.0.0.1:8080"), Xver: types.Int64Value(1)},
+			},
+		},
+		{
+			name: "multiple_partial",
+			list: []InboundFallbackModel{
+				{Dest: types.StringValue("a:80"), Xver: types.Int64Value(0)},
+				{Name: types.StringValue("x"), Dest: types.StringValue("b:443"), Alpn: types.StringValue("h3")},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandFallbacksFromModel(tc.list)
+			flat := flattenFallbacksToModel(expanded)
+			if len(flat) != len(tc.list) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.list))
+			}
+			for i, fb := range tc.list {
+				if fb.Dest.ValueString() != "" {
+					if flat[i].Dest.ValueString() != fb.Dest.ValueString() {
+						t.Fatalf("dest[%d] mismatch: got %q want %q", i, flat[i].Dest.ValueString(), fb.Dest.ValueString())
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_AccountsFromModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		list []InboundAccountModel
+	}{
+		{name: "empty", list: nil},
+		{
+			name: "single",
+			list: []InboundAccountModel{
+				{User: types.StringValue("u"), Pass: types.StringValue("p")},
+			},
+		},
+		{
+			name: "multiple",
+			list: []InboundAccountModel{
+				{User: types.StringValue("a"), Pass: types.StringValue("b")},
+				{User: types.StringValue("c"), Pass: types.StringValue("d")},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandAccountsFromModel(tc.list)
+			flat := flattenAccountsToModel(expanded)
+			if len(flat) != len(tc.list) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.list))
+			}
+			for i, acc := range tc.list {
+				if flat[i].User.ValueString() != acc.User.ValueString() {
+					t.Fatalf("user[%d] mismatch: got %q want %q", i, flat[i].User.ValueString(), acc.User.ValueString())
+				}
+				if flat[i].Pass.ValueString() != acc.Pass.ValueString() {
+					t.Fatalf("pass[%d] mismatch: got %q want %q", i, flat[i].Pass.ValueString(), acc.Pass.ValueString())
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Dokodemo / tunnel settings expand/flatten
+// ---------------------------------------------------------------------------
+
+func TestExpandFlatten_DokodemoInboundSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name     string
+		protocol string
+		model    *InboundDokodemoSettingsModel
+	}{
+		{
+			name:     "dokodemo_full",
+			protocol: "dokodemo-door",
+			model: &InboundDokodemoSettingsModel{
+				Address:        types.StringValue("127.0.0.1"),
+				Port:           types.Int64Value(8080),
+				Network:        types.StringValue("tcp,udp"),
+				FollowRedirect: types.BoolValue(true),
+			},
+		},
+		{
+			name:     "dokodemo_minimal",
+			protocol: "dokodemo-door",
+			model: &InboundDokodemoSettingsModel{
+				Address: types.StringValue("10.0.0.1"),
+				Port:    types.Int64Value(53),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandDokodemoInboundSettings(tc.protocol, tc.model)
+			if expanded == nil {
+				t.Fatal("expected non-nil expanded map")
+			}
+			flat := flattenDokodemoInboundSettings(tc.protocol, expanded)
+			if flat == nil {
+				t.Fatal("expected non-nil flattened model")
+			}
+			if flat.Address.ValueString() != tc.model.Address.ValueString() {
+				t.Fatalf("address mismatch: got %q want %q", flat.Address.ValueString(), tc.model.Address.ValueString())
+			}
+			if flat.Port.ValueInt64() != tc.model.Port.ValueInt64() {
+				t.Fatalf("port mismatch: got %d want %d", flat.Port.ValueInt64(), tc.model.Port.ValueInt64())
+			}
+		})
+	}
+}
+
+func TestExpandDokodemoInboundSettings_NilModel(t *testing.T) {
+	if got := expandDokodemoInboundSettings("dokodemo-door", nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+func TestExpandFlatten_DokodemoInboundSettings_WithPortMap(t *testing.T) {
+	portMap, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"80":  types.StringValue("127.0.0.1:8080"),
+		"443": types.StringValue("127.0.0.1:8443"),
+	})
+	model := &InboundDokodemoSettingsModel{
+		Address:        types.StringValue("127.0.0.1"),
+		Port:           types.Int64Value(80),
+		Network:        types.StringValue("tcp"),
+		PortMap:        portMap,
+		FollowRedirect: types.BoolValue(false),
+	}
+	expanded := expandDokodemoInboundSettings("dokodemo-door", model)
+	if expanded == nil {
+		t.Fatal("expected non-nil expanded map")
+	}
+	pm, ok := expanded["port_map"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected port_map in expanded, got %T", expanded["port_map"])
+	}
+	if pm["80"] != "127.0.0.1:8080" {
+		t.Fatalf("unexpected port_map[80]: %v", pm["80"])
+	}
+	flat := flattenDokodemoInboundSettings("dokodemo-door", expanded)
+	if flat == nil {
+		t.Fatal("expected non-nil flattened model")
+	}
+}

--- a/provider/stream_settings_expand_flatten_test.go
+++ b/provider/stream_settings_expand_flatten_test.go
@@ -1,0 +1,529 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Table-driven round-trip tests for inbound stream settings expand/flatten.
+// Each case builds a typed model, calls expand*FromModel, then flatten*ToModel,
+// and asserts the fields survive the round-trip.
+// ---------------------------------------------------------------------------
+
+func TestExpandFlatten_TCPSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *InboundTCPSettingsModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundTCPSettingsModel{
+				AcceptProxyProtocol: types.BoolValue(true),
+				HeaderType:          types.StringValue("http"),
+			},
+		},
+		{
+			name: "nulls",
+			model: &InboundTCPSettingsModel{
+				AcceptProxyProtocol: types.BoolNull(),
+				HeaderType:          types.StringNull(),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandTCPSettingsFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenTCPSettingsToModel(expanded)
+			if flat.AcceptProxyProtocol.ValueBool() != tc.model.AcceptProxyProtocol.ValueBool() {
+				t.Fatalf("accept_proxy_protocol mismatch: got %v want %v", flat.AcceptProxyProtocol.ValueBool(), tc.model.AcceptProxyProtocol.ValueBool())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_WSSettings_RoundTrip(t *testing.T) {
+	headersVal, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"Host": types.StringValue("example.com"),
+	})
+	cases := []struct {
+		name  string
+		model *InboundWSSettingsModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundWSSettingsModel{
+				Path:    types.StringValue("/ray"),
+				Headers: headersVal,
+			},
+		},
+		{
+			name: "path_only",
+			model: &InboundWSSettingsModel{
+				Path: types.StringValue("/ws"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandWSSettingsFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenWSSettingsToModel(expanded)
+			if flat.Path.ValueString() != tc.model.Path.ValueString() {
+				t.Fatalf("path mismatch: got %q want %q", flat.Path.ValueString(), tc.model.Path.ValueString())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_GRPCSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *InboundGRPCSettingsModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundGRPCSettingsModel{
+				ServiceName:         types.StringValue("GunService"),
+				MultiMode:           types.BoolValue(true),
+				IdleTimeout:         types.Int64Value(60),
+				HealthCheckTimeout:  types.Int64Value(20),
+				PermitWithoutStream: types.BoolValue(false),
+				InitialWindowsSize:  types.Int64Value(0),
+			},
+		},
+		{
+			name: "minimal",
+			model: &InboundGRPCSettingsModel{
+				ServiceName: types.StringValue("grpc"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandGRPCSettingsFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenGRPCSettingsToModel(expanded)
+			if flat.ServiceName.ValueString() != tc.model.ServiceName.ValueString() {
+				t.Fatalf("service_name mismatch: got %q want %q", flat.ServiceName.ValueString(), tc.model.ServiceName.ValueString())
+			}
+			if flat.MultiMode.ValueBool() != tc.model.MultiMode.ValueBool() {
+				t.Fatalf("multi_mode mismatch: got %v want %v", flat.MultiMode.ValueBool(), tc.model.MultiMode.ValueBool())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_HTTPUpgradeSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *InboundHTTPUpgradeSettingsModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundHTTPUpgradeSettingsModel{
+				Path: types.StringValue("/upgrade"),
+				Host: types.StringValue("cdn.example.com"),
+			},
+		},
+		{
+			name: "path_only",
+			model: &InboundHTTPUpgradeSettingsModel{
+				Path: types.StringValue("/upg"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandHTTPUpgradeSettingsFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenHTTPUpgradeSettingsToModel(expanded)
+			if flat.Path.ValueString() != tc.model.Path.ValueString() {
+				t.Fatalf("path mismatch: got %q want %q", flat.Path.ValueString(), tc.model.Path.ValueString())
+			}
+			if flat.Host.ValueString() != tc.model.Host.ValueString() {
+				t.Fatalf("host mismatch: got %q want %q", flat.Host.ValueString(), tc.model.Host.ValueString())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_XHTTPSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *InboundXHTTPSettingsModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundXHTTPSettingsModel{
+				Path:              types.StringValue("/xhttp"),
+				Mode:              types.StringValue("auto"),
+				NoSSEHeader:       types.BoolValue(true),
+				KeepAliveInterval: types.Int64Value(30),
+				XPaddingBytes:     types.StringValue("100-1000"),
+				XPaddingObfsMode:  types.BoolValue(false),
+				XPaddingKey:       types.StringValue("key1"),
+				XPaddingHeader:    types.StringValue("X-Padding"),
+				XPaddingPlacement: types.StringValue("header"),
+				XPaddingMethod:    types.StringValue(" aes-256-gcm"),
+			},
+		},
+		{
+			name: "minimal",
+			model: &InboundXHTTPSettingsModel{
+				Mode: types.StringValue("packet-up"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandXHTTPSettingsFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenXHTTPSettingsToModel(expanded)
+			if flat.Mode.ValueString() != tc.model.Mode.ValueString() {
+				t.Fatalf("mode mismatch: got %q want %q", flat.Mode.ValueString(), tc.model.Mode.ValueString())
+			}
+			if flat.NoSSEHeader.ValueBool() != tc.model.NoSSEHeader.ValueBool() {
+				t.Fatalf("no_sse_header mismatch: got %v want %v", flat.NoSSEHeader.ValueBool(), tc.model.NoSSEHeader.ValueBool())
+			}
+			if flat.KeepAliveInterval.ValueInt64() != tc.model.KeepAliveInterval.ValueInt64() {
+				t.Fatalf("keep_alive_interval mismatch: got %d want %d", flat.KeepAliveInterval.ValueInt64(), tc.model.KeepAliveInterval.ValueInt64())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_KCPSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *InboundKCPSettingsModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundKCPSettingsModel{
+				MTU:              types.Int64Value(1350),
+				TTI:              types.Int64Value(50),
+				UplinkCapacity:   types.Int64Value(5),
+				DownlinkCapacity: types.Int64Value(20),
+				CwndMultiplier:   types.Int64Value(2),
+				MaxSendingWindow: types.Int64Value(1024),
+				HeaderType:       types.StringValue("srtp"),
+			},
+		},
+		{
+			name:  "all_null",
+			model: &InboundKCPSettingsModel{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandKCPSettingsFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenKCPSettingsToModel(expanded)
+			if flat.MTU.ValueInt64() != tc.model.MTU.ValueInt64() {
+				t.Fatalf("mtu mismatch: got %d want %d", flat.MTU.ValueInt64(), tc.model.MTU.ValueInt64())
+			}
+			if flat.HeaderType.ValueString() != tc.model.HeaderType.ValueString() {
+				t.Fatalf("header_type mismatch: got %q want %q", flat.HeaderType.ValueString(), tc.model.HeaderType.ValueString())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_HysteriaStreamSettings_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *InboundHysteriaStreamSettingsModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundHysteriaStreamSettingsModel{
+				Protocol:       types.StringValue("udp"),
+				Version:        types.Int64Value(2),
+				Auth:           types.StringValue("password123"),
+				UDPIdleTimeout: types.Int64Value(30),
+			},
+		},
+		{
+			name:  "all_null",
+			model: &InboundHysteriaStreamSettingsModel{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandHysteriaStreamSettingsFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenHysteriaStreamSettingsToModel(expanded)
+			if flat.Protocol.ValueString() != tc.model.Protocol.ValueString() {
+				t.Fatalf("protocol mismatch: got %q want %q", flat.Protocol.ValueString(), tc.model.Protocol.ValueString())
+			}
+			if flat.Version.ValueInt64() != tc.model.Version.ValueInt64() {
+				t.Fatalf("version mismatch: got %d want %d", flat.Version.ValueInt64(), tc.model.Version.ValueInt64())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_Sockopt_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		model *InboundSockoptModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundSockoptModel{
+				Mark:                 types.Int64Value(255),
+				TCPKeepAliveInterval: types.Int64Value(15),
+				TCPNoDelay:           types.BoolValue(true),
+				TFOEnable:            types.BoolValue(true),
+				Tproxy:               types.StringValue("redirect"),
+				DomainStrategy:       types.StringValue("UseIP"),
+			},
+		},
+		{
+			name:  "all_null",
+			model: &InboundSockoptModel{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandSockoptFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenSockoptToModel(expanded)
+			if flat.Tproxy.ValueString() != tc.model.Tproxy.ValueString() {
+				t.Fatalf("tproxy mismatch: got %q want %q", flat.Tproxy.ValueString(), tc.model.Tproxy.ValueString())
+			}
+			if flat.DomainStrategy.ValueString() != tc.model.DomainStrategy.ValueString() {
+				t.Fatalf("domain_strategy mismatch: got %q want %q", flat.DomainStrategy.ValueString(), tc.model.DomainStrategy.ValueString())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_RealitySettings_RoundTrip(t *testing.T) {
+	serverNames, _ := types.ListValue(types.StringType, []attr.Value{
+		types.StringValue("example.com"),
+		types.StringValue("www.example.com"),
+	})
+	shortIDs, _ := types.ListValue(types.StringType, []attr.Value{
+		types.StringValue("abc123"),
+		types.StringValue(""),
+	})
+	cases := []struct {
+		name  string
+		model *InboundRealitySettingsModel
+	}{
+		{name: "nil_model", model: nil},
+		{
+			name: "full",
+			model: &InboundRealitySettingsModel{
+				Show:        types.BoolValue(true),
+				Xver:        types.Int64Value(1),
+				Target:      types.StringValue("google.com:443"),
+				ServerNames: serverNames,
+				PrivateKey:  types.StringValue("priv"),
+				ShortIDs:    shortIDs,
+			},
+		},
+		{
+			name:  "all_null",
+			model: &InboundRealitySettingsModel{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandRealitySettingsFromModel(tc.model)
+			if tc.model == nil {
+				if expanded != nil {
+					t.Fatalf("expected nil, got %v", expanded)
+				}
+				return
+			}
+			flat := flattenRealitySettingsToModel(expanded)
+			if flat.Target.ValueString() != tc.model.Target.ValueString() {
+				t.Fatalf("target mismatch: got %q want %q", flat.Target.ValueString(), tc.model.Target.ValueString())
+			}
+			if flat.Xver.ValueInt64() != tc.model.Xver.ValueInt64() {
+				t.Fatalf("xver mismatch: got %d want %d", flat.Xver.ValueInt64(), tc.model.Xver.ValueInt64())
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_ExternalProxy_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		list []InboundExternalProxyModel
+	}{
+		{name: "empty", list: nil},
+		{
+			name: "single",
+			list: []InboundExternalProxyModel{
+				{Dest: types.StringValue("1.2.3.4"), Port: types.Int64Value(443), Remark: types.StringValue("proxy1"), ForceTLS: types.StringValue("tls")},
+			},
+		},
+		{
+			name: "multiple_partial",
+			list: []InboundExternalProxyModel{
+				{Dest: types.StringValue("a.com"), Port: types.Int64Value(8080)},
+				{Dest: types.StringValue("b.com"), Port: types.Int64Value(8443), Remark: types.StringValue("b")},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandExternalProxyFromModel(tc.list)
+			flat := flattenExternalProxyToModel(expanded)
+			if len(flat) != len(tc.list) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.list))
+			}
+			for i, ep := range tc.list {
+				if flat[i].Dest.ValueString() != ep.Dest.ValueString() {
+					t.Fatalf("dest[%d] mismatch: got %q want %q", i, flat[i].Dest.ValueString(), ep.Dest.ValueString())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_StreamSettingsModel_Nil(t *testing.T) {
+	if got := expandStreamSettingsFromModel(nil); got != nil {
+		t.Fatalf("expected nil for nil model, got %v", got)
+	}
+}
+
+func TestExpandFlatten_StreamSettingsModel_EmptyData(t *testing.T) {
+	flat := flattenStreamSettingsToModel(map[string]any{})
+	if flat == nil {
+		t.Fatal("expected non-nil model for empty data")
+	}
+	if !flat.Network.IsNull() {
+		t.Fatalf("expected null network for empty data, got %v", flat.Network)
+	}
+}
+
+func TestExpandFlatten_StreamSettingsModel_RoundTrip(t *testing.T) {
+	model := &InboundStreamSettingsModel{
+		Network:     types.StringValue("ws"),
+		Security:    types.StringValue("none"),
+		TCPSettings: &InboundTCPSettingsModel{
+			AcceptProxyProtocol: types.BoolValue(true),
+			HeaderType:          types.StringValue("none"),
+		},
+		WSSettings: &InboundWSSettingsModel{
+			Path: types.StringValue("/v2ray"),
+		},
+		Sockopt: &InboundSockoptModel{
+			TCPNoDelay: types.BoolValue(true),
+			Tproxy:     types.StringValue("tproxy"),
+		},
+	}
+	expanded := expandStreamSettingsFromModel(model)
+	if expanded == nil {
+		t.Fatal("expected non-nil expanded map")
+	}
+	if expanded["network"] != "ws" {
+		t.Fatalf("unexpected network: %v", expanded["network"])
+	}
+	flat := flattenStreamSettingsToModel(expanded)
+	if flat == nil {
+		t.Fatal("expected non-nil flattened model")
+	}
+	if flat.Network.ValueString() != "ws" {
+		t.Fatalf("network mismatch: got %q want %q", flat.Network.ValueString(), "ws")
+	}
+	if flat.TCPSettings == nil {
+		t.Fatal("expected TCPSettings to be set")
+	}
+	if flat.WSSettings == nil {
+		t.Fatal("expected WSSettings to be set")
+	}
+	if flat.Sockopt == nil {
+		t.Fatal("expected Sockopt to be set")
+	}
+}
+
+func TestExpandFlatten_RealityInnerSettings_RoundTrip(t *testing.T) {
+	obj, _ := types.ObjectValue(realityInnerSettingsAttrTypes, map[string]attr.Value{
+		"public_key":     types.StringValue("pub123"),
+		"fingerprint":    types.StringValue("chrome"),
+		"server_name":    types.StringValue("sni.example.com"),
+		"spider_x":       types.StringValue(""),
+		"mldsa65_verify": types.StringValue(""),
+	})
+	expanded := expandRealityInnerSettingsFromObject(obj)
+	if expanded["public_key"] != "pub123" {
+		t.Fatalf("unexpected public_key: %v", expanded["public_key"])
+	}
+	if expanded["fingerprint"] != "chrome" {
+		t.Fatalf("unexpected fingerprint: %v", expanded["fingerprint"])
+	}
+	flatObj := flattenRealityInnerSettingsToObject(expanded)
+	if flatObj.Attributes()["public_key"].(types.String).ValueString() != "pub123" {
+		t.Fatalf("unexpected public_key in flat obj")
+	}
+}
+
+func TestExpandRealityInnerSettingsFromObject_Null(t *testing.T) {
+	if got := expandRealityInnerSettingsFromObject(types.ObjectNull(realityInnerSettingsAttrTypes)); got != nil {
+		t.Fatalf("expected nil for null object, got %v", got)
+	}
+}
+
+func TestFlattenRealityInnerSettingsToObject_Empty(t *testing.T) {
+	obj := flattenRealityInnerSettingsToObject(map[string]any{})
+	if !obj.IsNull() {
+		t.Fatalf("expected null object for empty data, got %v", obj)
+	}
+}

--- a/provider/xray_outbounds_expand_flatten_test.go
+++ b/provider/xray_outbounds_expand_flatten_test.go
@@ -1,0 +1,754 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ---------------------------------------------------------------------------
+// Table-driven round-trip tests for xray outbound per-protocol expand/flatten.
+//
+// There are TWO expand/flatten pairs per protocol:
+//  1. expandXxxSettingsFromModel ([]TypedModel -> []any) / flattenXxxSettingsToModel ([]any -> []TypedModel)
+//  2. expandXxxOutSettings (map[settings_key]->Xray JSON) / flattenXxxOutSettings (Xray JSON -> map)
+//
+// Both are tested here.
+// ---------------------------------------------------------------------------
+
+// --- VLESS ---
+
+func TestExpandFlatten_VlessOutModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []XrayVlessOutSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayVlessOutSettings{
+				{
+					Address:    types.StringValue("1.2.3.4"),
+					Port:       types.Int64Value(443),
+					ID:         types.StringValue("uuid-1234"),
+					Flow:       types.StringValue("xtls-rprx-vision"),
+					Encryption: types.StringValue("none"),
+					ReverseTag: types.StringValue("rev"),
+				},
+			},
+		},
+		{
+			name: "nulls",
+			input: []XrayVlessOutSettings{{}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandVlessSettingsFromModel(tc.input)
+			flat := flattenVlessSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, vs := range tc.input {
+				if flat[i].Address.ValueString() != vs.Address.ValueString() {
+					t.Fatalf("address[%d] mismatch: got %q want %q", i, flat[i].Address.ValueString(), vs.Address.ValueString())
+				}
+				if flat[i].ID.ValueString() != vs.ID.ValueString() {
+					t.Fatalf("id[%d] mismatch: got %q want %q", i, flat[i].ID.ValueString(), vs.ID.ValueString())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_VlessOutJSON_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		data map[string]any
+	}{
+		{name: "empty", data: map[string]any{}},
+		{
+			name: "full",
+			data: map[string]any{
+				"vless_settings": []any{
+					map[string]any{
+						"address":     "1.2.3.4",
+						"port":        443,
+						"id":          "uuid-1234",
+						"flow":        "xtls-rprx-vision",
+						"encryption":  "none",
+						"reverse_tag": "rev",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			xrayJSON := expandVlessOutSettings(tc.data)
+			flat := flattenVlessOutSettings(xrayJSON)
+			// For empty input expandVlessOutSettings returns nil
+			if tc.name == "empty" {
+				if xrayJSON != nil {
+					t.Fatalf("expected nil for empty, got %v", xrayJSON)
+				}
+				return
+			}
+			if flat["address"] != "1.2.3.4" {
+				t.Fatalf("address mismatch: got %v want %v", flat["address"], "1.2.3.4")
+			}
+			if flat["id"] != "uuid-1234" {
+				t.Fatalf("id mismatch: got %v want %v", flat["id"], "uuid-1234")
+			}
+			if flat["reverse_tag"] != "rev" {
+				t.Fatalf("reverse_tag mismatch: got %v want %v", flat["reverse_tag"], "rev")
+			}
+		})
+	}
+}
+
+// --- VMess ---
+
+func TestExpandFlatten_VmessOutModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []XrayVmessOutSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayVmessOutSettings{
+				{
+					Address:  types.StringValue("5.6.7.8"),
+					Port:     types.Int64Value(8443),
+					ID:       types.StringValue("vmess-uuid"),
+					Security: types.StringValue("aes-128-gcm"),
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandVmessSettingsFromModel(tc.input)
+			flat := flattenVmessSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, vs := range tc.input {
+				if flat[i].Address.ValueString() != vs.Address.ValueString() {
+					t.Fatalf("address[%d] mismatch: got %q want %q", i, flat[i].Address.ValueString(), vs.Address.ValueString())
+				}
+				if flat[i].Security.ValueString() != vs.Security.ValueString() {
+					t.Fatalf("security[%d] mismatch: got %q want %q", i, flat[i].Security.ValueString(), vs.Security.ValueString())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_VmessOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"vmess_settings": []any{
+			map[string]any{
+				"address":  "5.6.7.8",
+				"port":     8443,
+				"id":       "uuid-vmess",
+				"security": "auto",
+			},
+		},
+	}
+	xrayJSON := expandVmessOutSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenVmessOutSettings(xrayJSON)
+	if flat["address"] != "5.6.7.8" {
+		t.Fatalf("address mismatch: got %v want %v", flat["address"], "5.6.7.8")
+	}
+	if flat["security"] != "auto" {
+		t.Fatalf("security mismatch: got %v want %v", flat["security"], "auto")
+	}
+}
+
+// --- Trojan ---
+
+func TestExpandFlatten_TrojanOutModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []XrayTrojanOutSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayTrojanOutSettings{
+				{
+					Address:  types.StringValue("trojan.example.com"),
+					Port:     types.Int64Value(443),
+					Password: types.StringValue("pass123"),
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandTrojanSettingsFromModel(tc.input)
+			flat := flattenTrojanSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, ts := range tc.input {
+				if flat[i].Address.ValueString() != ts.Address.ValueString() {
+					t.Fatalf("address[%d] mismatch: got %q want %q", i, flat[i].Address.ValueString(), ts.Address.ValueString())
+				}
+				if flat[i].Password.ValueString() != ts.Password.ValueString() {
+					t.Fatalf("password[%d] mismatch: got %q want %q", i, flat[i].Password.ValueString(), ts.Password.ValueString())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_TrojanOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"trojan_settings": []any{
+			map[string]any{
+				"address":  "trojan.example.com",
+				"port":     443,
+				"password": "secret",
+			},
+		},
+	}
+	xrayJSON := expandTrojanOutSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenTrojanOutSettings(xrayJSON)
+	if flat["address"] != "trojan.example.com" {
+		t.Fatalf("address mismatch: got %v want %v", flat["address"], "trojan.example.com")
+	}
+	if flat["password"] != "secret" {
+		t.Fatalf("password mismatch: got %v want %v", flat["password"], "secret")
+	}
+}
+
+// --- Shadowsocks ---
+
+func TestExpandFlatten_ShadowsocksOutModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []XrayShadowsocksOutSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayShadowsocksOutSettings{
+				{
+					Address:    types.StringValue("ss.example.com"),
+					Port:       types.Int64Value(8388),
+					Password:   types.StringValue("ss-pass"),
+					Method:     types.StringValue("aes-256-gcm"),
+					UOT:        types.BoolValue(true),
+					UOTVersion: types.Int64Value(2),
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandShadowsocksSettingsFromModel(tc.input)
+			flat := flattenShadowsocksSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, ss := range tc.input {
+				if flat[i].Method.ValueString() != ss.Method.ValueString() {
+					t.Fatalf("method[%d] mismatch: got %q want %q", i, flat[i].Method.ValueString(), ss.Method.ValueString())
+				}
+				if flat[i].UOT.ValueBool() != ss.UOT.ValueBool() {
+					t.Fatalf("uot[%d] mismatch: got %v want %v", i, flat[i].UOT.ValueBool(), ss.UOT.ValueBool())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_ShadowsocksOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"shadowsocks_settings": []any{
+			map[string]any{
+				"address":     "ss.example.com",
+				"port":        8388,
+				"password":    "ss-pass",
+				"method":      "chacha20-ietf-poly1305",
+				"uot":         true,
+				"uot_version": 2,
+			},
+		},
+	}
+	xrayJSON := expandShadowsocksOutSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenShadowsocksOutSettings(xrayJSON)
+	if flat["address"] != "ss.example.com" {
+		t.Fatalf("address mismatch: got %v want %v", flat["address"], "ss.example.com")
+	}
+	if flat["method"] != "chacha20-ietf-poly1305" {
+		t.Fatalf("method mismatch: got %v want %v", flat["method"], "chacha20-ietf-poly1305")
+	}
+	if flat["uot"] != true {
+		t.Fatalf("uot mismatch: got %v want %v", flat["uot"], true)
+	}
+}
+
+// --- SOCKS ---
+
+func TestExpandFlatten_SocksOutModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []XraySocksOutSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XraySocksOutSettings{
+				{
+					Address: types.StringValue("socks.example.com"),
+					Port:    types.Int64Value(1080),
+					User:    types.StringValue("socksuser"),
+					Pass:    types.StringValue("sockspass"),
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandSocksSettingsFromModel(tc.input)
+			flat := flattenSocksSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, ss := range tc.input {
+				if flat[i].User.ValueString() != ss.User.ValueString() {
+					t.Fatalf("user[%d] mismatch: got %q want %q", i, flat[i].User.ValueString(), ss.User.ValueString())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_SocksOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"socks_settings": []any{
+			map[string]any{
+				"address": "socks.example.com",
+				"port":    1080,
+				"user":    "su",
+				"pass":    "sp",
+			},
+		},
+	}
+	xrayJSON := expandSocksOutSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenSocksOutSettings(xrayJSON)
+	if flat["address"] != "socks.example.com" {
+		t.Fatalf("address mismatch: got %v want %v", flat["address"], "socks.example.com")
+	}
+	if flat["user"] != "su" {
+		t.Fatalf("user mismatch: got %v want %v", flat["user"], "su")
+	}
+}
+
+// --- HTTP ---
+
+func TestExpandFlatten_HTTPOutModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []XrayHTTPOutSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayHTTPOutSettings{
+				{
+					Address: types.StringValue("http.example.com"),
+					Port:    types.Int64Value(8080),
+					User:    types.StringValue("httpuser"),
+					Pass:    types.StringValue("httppass"),
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandHTTPSettingsFromModel(tc.input)
+			flat := flattenHTTPSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, hs := range tc.input {
+				if flat[i].User.ValueString() != hs.User.ValueString() {
+					t.Fatalf("user[%d] mismatch: got %q want %q", i, flat[i].User.ValueString(), hs.User.ValueString())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_HTTPOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"http_settings": []any{
+			map[string]any{
+				"address": "http.example.com",
+				"port":    8080,
+				"user":    "hu",
+				"pass":    "hp",
+			},
+		},
+	}
+	xrayJSON := expandHTTPOutSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenHTTPOutSettings(xrayJSON)
+	if flat["address"] != "http.example.com" {
+		t.Fatalf("address mismatch: got %v want %v", flat["address"], "http.example.com")
+	}
+	if flat["user"] != "hu" {
+		t.Fatalf("user mismatch: got %v want %v", flat["user"], "hu")
+	}
+}
+
+// --- Hysteria ---
+
+func TestExpandFlatten_HysteriaOutModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []XrayHysteriaOutSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayHysteriaOutSettings{
+				{
+					Address: types.StringValue("hy.example.com"),
+					Port:    types.Int64Value(36712),
+					Version: types.Int64Value(2),
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandHysteriaSettingsFromModel(tc.input)
+			flat := flattenHysteriaSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, hs := range tc.input {
+				if flat[i].Version.ValueInt64() != hs.Version.ValueInt64() {
+					t.Fatalf("version[%d] mismatch: got %d want %d", i, flat[i].Version.ValueInt64(), hs.Version.ValueInt64())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_HysteriaOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"hysteria_settings": []any{
+			map[string]any{
+				"address": "hy.example.com",
+				"port":    36712,
+				"version": 2,
+			},
+		},
+	}
+	xrayJSON := expandHysteriaOutSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenHysteriaOutSettings(xrayJSON)
+	if flat["address"] != "hy.example.com" {
+		t.Fatalf("address mismatch: got %v want %v", flat["address"], "hy.example.com")
+	}
+	if flat["version"] != 2 {
+		t.Fatalf("version mismatch: got %v want %v", flat["version"], 2)
+	}
+}
+
+// --- Blackhole ---
+
+func TestExpandFlatten_BlackholeOutModel_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []XrayBlackholeSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "with_type",
+			input: []XrayBlackholeSettings{
+				{ResponseType: types.StringValue("http")},
+			},
+		},
+		{
+			name:  "null_type",
+			input: []XrayBlackholeSettings{{ResponseType: types.StringNull()}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandBlackholeSettingsFromModel(tc.input)
+			flat := flattenBlackholeSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_BlackholeOutJSON_RoundTrip(t *testing.T) {
+	// Expand with a response_type
+	data := map[string]any{
+		"blackhole_settings": []any{
+			map[string]any{"response_type": "none"},
+		},
+	}
+	xrayJSON := expandBlackholeSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenBlackholeSettings(xrayJSON)
+	if flat["response_type"] != "none" {
+		t.Fatalf("response_type mismatch: got %v want %v", flat["response_type"], "none")
+	}
+
+	// Flatten empty input should default to "none"
+	flat2 := flattenBlackholeSettings(map[string]any{})
+	if flat2["response_type"] != "none" {
+		t.Fatalf("default response_type mismatch: got %v want %v", flat2["response_type"], "none")
+	}
+}
+
+// --- DNS ---
+
+func TestExpandFlatten_DNSOutModel_RoundTrip(t *testing.T) {
+	blockTypes, _ := types.ListValue(types.Int64Type, []attr.Value{
+		types.Int64Value(1),
+		types.Int64Value(2),
+	})
+	cases := []struct {
+		name  string
+		input []XrayOutboundDNSSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayOutboundDNSSettings{
+				{
+					Network:    types.StringValue("tcp"),
+					Address:    types.StringValue("1.1.1.1"),
+					Port:       types.Int64Value(53),
+					NonIPQuery: types.StringValue("drop"),
+					BlockTypes: blockTypes,
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandDNSSettingsFromModel(tc.input)
+			flat := flattenDNSSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, ds := range tc.input {
+				if flat[i].Network.ValueString() != ds.Network.ValueString() {
+					t.Fatalf("network[%d] mismatch: got %q want %q", i, flat[i].Network.ValueString(), ds.Network.ValueString())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_DNSOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"dns_settings": []any{
+			map[string]any{
+				"network":      "tcp",
+				"address":      "8.8.8.8",
+				"port":         53,
+				"non_ip_query": "skip",
+				"block_types":  []any{float64(1), float64(3)},
+			},
+		},
+	}
+	xrayJSON := expandOutboundDNSSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenOutboundDNSSettings(xrayJSON)
+	if flat["network"] != "tcp" {
+		t.Fatalf("network mismatch: got %v want %v", flat["network"], "tcp")
+	}
+	if flat["non_ip_query"] != "skip" {
+		t.Fatalf("non_ip_query mismatch: got %v want %v", flat["non_ip_query"], "skip")
+	}
+}
+
+// --- Freedom ---
+
+func TestExpandFlatten_FreedomOutModel_RoundTrip(t *testing.T) {
+	ipsBlocked, _ := types.ListValue(types.StringType, []attr.Value{
+		types.StringValue("geoip:cn"),
+		types.StringValue("geoip:private"),
+	})
+	cases := []struct {
+		name  string
+		input []XrayFreedomSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayFreedomSettings{
+				{
+					DomainStrategy: types.StringValue("UseIPv4"),
+					Redirect:       types.StringValue(":0"),
+					Fragment: []XrayFreedomFragment{
+						{Packets: types.StringValue("tlshello"), Length: types.StringValue("100-200"), Interval: types.StringValue("10-20")},
+					},
+					IPsBlocked: ipsBlocked,
+				},
+			},
+		},
+		{
+			name:  "all_null",
+			input: []XrayFreedomSettings{{}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandFreedomSettingsFromModel(tc.input)
+			flat := flattenFreedomSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, fs := range tc.input {
+				if flat[i].DomainStrategy.ValueString() != fs.DomainStrategy.ValueString() {
+					t.Fatalf("domain_strategy[%d] mismatch: got %q want %q", i, flat[i].DomainStrategy.ValueString(), fs.DomainStrategy.ValueString())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_FreedomOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"freedom_settings": []any{
+			map[string]any{
+				"domain_strategy": "AsIs",
+				"redirect":        "127.0.0.1:0",
+				"fragment": []any{
+					map[string]any{
+						"packets":  "tlshello",
+						"length":   "100-200",
+						"interval": "10-20",
+					},
+				},
+			},
+		},
+	}
+	xrayJSON := expandFreedomSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	if xrayJSON["domainStrategy"] != "AsIs" {
+		t.Fatalf("domainStrategy mismatch: got %v want %v", xrayJSON["domainStrategy"], "AsIs")
+	}
+	flat := flattenFreedomSettings(xrayJSON)
+	if flat["domain_strategy"] != "AsIs" {
+		t.Fatalf("domain_strategy mismatch: got %v want %v", flat["domain_strategy"], "AsIs")
+	}
+}
+
+// --- Wireguard ---
+
+func TestExpandFlatten_WireguardOutModel_RoundTrip(t *testing.T) {
+	addr, _ := types.ListValue(types.StringType, []attr.Value{
+		types.StringValue("172.16.0.1/32"),
+	})
+	reserved, _ := types.ListValue(types.Int64Type, []attr.Value{
+		types.Int64Value(10),
+		types.Int64Value(20),
+	})
+	allowedIPs, _ := types.ListValue(types.StringType, []attr.Value{
+		types.StringValue("0.0.0.0/0"),
+	})
+	cases := []struct {
+		name  string
+		input []XrayWireguardOutSettings
+	}{
+		{name: "empty", input: nil},
+		{
+			name: "full",
+			input: []XrayWireguardOutSettings{
+				{
+					MTU:            types.Int64Value(1280),
+					SecretKey:      types.StringValue("secret"),
+					Address:        addr,
+					Workers:        types.Int64Value(2),
+					DomainStrategy: types.StringValue("UseIPv4v6"),
+					Reserved:       reserved,
+					NoKernelTun:    types.BoolValue(true),
+					Peer: []XrayWireguardPeer{
+						{PublicKey: types.StringValue("pub"), PreSharedKey: types.StringValue("psk"), AllowedIPs: allowedIPs, Endpoint: types.StringValue("1.2.3.4:51820"), KeepAlive: types.Int64Value(0)},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expanded := expandWireguardSettingsFromModel(tc.input)
+			flat := flattenWireguardSettingsToModel(expanded)
+			if len(flat) != len(tc.input) {
+				t.Fatalf("count mismatch: got %d want %d", len(flat), len(tc.input))
+			}
+			for i, wg := range tc.input {
+				if flat[i].MTU.ValueInt64() != wg.MTU.ValueInt64() {
+					t.Fatalf("mtu[%d] mismatch: got %d want %d", i, flat[i].MTU.ValueInt64(), wg.MTU.ValueInt64())
+				}
+			}
+		})
+	}
+}
+
+func TestExpandFlatten_WireguardOutJSON_RoundTrip(t *testing.T) {
+	data := map[string]any{
+		"wireguard_settings": []any{
+			map[string]any{
+				"mtu":            1280,
+				"secret_key":     "priv",
+				"address":        []any{"172.16.0.1/32"},
+				"workers":        2,
+				"domain_strategy": "UseIP",
+				"reserved":       []any{float64(10), float64(20)},
+				"no_kernel_tun":  true,
+			},
+		},
+	}
+	xrayJSON := expandWireguardOutSettings(data)
+	if xrayJSON == nil {
+		t.Fatal("expected non-nil xrayJSON")
+	}
+	flat := flattenWireguardOutSettings(xrayJSON)
+	if flat["secret_key"] != "priv" {
+		t.Fatalf("secret_key mismatch: got %v want %v", flat["secret_key"], "priv")
+	}
+	if flat["no_kernel_tun"] != true {
+		t.Fatalf("no_kernel_tun mismatch: got %v want %v", flat["no_kernel_tun"], true)
+	}
+}


### PR DESCRIPTION
Closes #345

4 test files, 65 new test functions, 2032 lines covering:
- inbound settings (vless/trojan/shadowsocks/http/socks)
- stream settings (reality/tcp/ws/grpc/kcp/hysteria/sockopt)
- xray outbounds (11 protocols)
- Client.GetNewX25519Cert/GetNewVlessEnc via httptest