### PR TITLE
feat: add typed mtproto_settings block to threexui_inbound

### DIFF
--- a/provider/drift_test.go
+++ b/provider/drift_test.go
@@ -632,9 +632,7 @@ func TestDriftInboundProtocols_GoModel(t *testing.T) {
 	}
 
 	upstreamSet := toSet(upstream)
-	upstreamSkipped := map[string]bool{
-		"mtproto": true, // managed mtg sidecar, not an xray inbound protocol
-	}
+	upstreamSkipped := map[string]bool{}
 	checkMissing(t, upstream, providerHandled, upstreamSkipped,
 		"upstream model.go has protocols not handled by provider: %v")
 	checkRemoved(t, providerHandled, upstreamSet, providerExtras,
@@ -672,9 +670,7 @@ func TestDriftInboundProtocols_JS(t *testing.T) {
 	}
 
 	upstreamSet := toSet(upstream)
-	upstreamSkipped := map[string]bool{
-		"mtproto": true, // managed mtg sidecar, not an xray inbound protocol
-	}
+	upstreamSkipped := map[string]bool{}
 	checkMissing(t, upstream, providerHandled, upstreamSkipped,
 		"upstream inbound.js Protocols has entries not handled by provider: %v")
 	checkRemoved(t, providerHandled, upstreamSet, providerExtras,
@@ -712,9 +708,7 @@ func TestDriftProtocolForms(t *testing.T) {
 	}
 
 	upstreamSet := toSet(upstream)
-	upstreamSkipped := map[string]bool{
-		"mtproto": true, // managed mtg sidecar, not an xray inbound protocol
-	}
+	upstreamSkipped := map[string]bool{}
 	checkMissing(t, upstream, providerBlocks, upstreamSkipped,
 		"upstream protocol form files not handled by provider: %v")
 	checkRemoved(t, providerBlocks, upstreamSet, providerExtras,

--- a/provider/inbound_settings_schema.go
+++ b/provider/inbound_settings_schema.go
@@ -79,6 +79,25 @@ type InboundHysteriaSettingsModel struct {
 	Version types.Int64 `tfsdk:"version"`
 }
 
+type InboundMtprotoSettingsModel struct {
+	FakeTlsDomain          types.String                      `tfsdk:"fake_tls_domain"`
+	ProxyProtocolListener  types.Bool                        `tfsdk:"proxy_protocol_listener"`
+	PreferIp               types.String                      `tfsdk:"prefer_ip"`
+	Debug                  types.Bool                        `tfsdk:"debug"`
+	DomainFronting         []InboundMtprotoDomainFrontingModel `tfsdk:"domain_fronting"`
+	OutboundTag            types.String                      `tfsdk:"outbound_tag"`
+	RouteThroughXray       types.Bool                        `tfsdk:"route_through_xray"`
+	RouteXrayPort          types.Int64                       `tfsdk:"route_xray_port"`
+	PublicIpv4             types.String                      `tfsdk:"public_ipv4"`
+	PublicIpv6             types.String                      `tfsdk:"public_ipv6"`
+}
+
+type InboundMtprotoDomainFrontingModel struct {
+	IP            types.String `tfsdk:"ip"`
+	Port          types.Int64  `tfsdk:"port"`
+	ProxyProtocol types.Bool   `tfsdk:"proxy_protocol"`
+}
+
 // Sub-models
 
 type InboundAccountModel struct {
@@ -471,6 +490,113 @@ func inboundSettingsBlockSchemas() map[string]schema.Block {
 				},
 			},
 		},
+		"mtproto_settings": schema.SingleNestedBlock{
+			Description: "Settings for MTProto protocol (3x-ui v3.3.0+). fake_tls_domain is the key field used by the panel to heal per-client FakeTLS secrets.",
+			Attributes: map[string]schema.Attribute{
+				"fake_tls_domain": schema.StringAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "FakeTLS domain (default 'www.cloudflare.com'). Used by the panel to rebuild per-client secret domain suffixes.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"proxy_protocol_listener": schema.BoolAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "Enable PROXY protocol listener.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"prefer_ip": schema.StringAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "IP preference: prefer-ipv6, prefer-ipv4, only-ipv6, or only-ipv4.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"debug": schema.BoolAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "Enable debug mode.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"outbound_tag": schema.StringAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "Outbound tag for routing.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"route_through_xray": schema.BoolAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "Route traffic through Xray core.",
+					PlanModifiers: []planmodifier.Bool{
+						boolplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"route_xray_port": schema.Int64Attribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "Port for Xray routing.",
+					PlanModifiers: []planmodifier.Int64{
+						int64planmodifier.UseStateForUnknown(),
+					},
+				},
+				"public_ipv4": schema.StringAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "Public IPv4 address.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+				"public_ipv6": schema.StringAttribute{
+					Optional:    true,
+					Computed:    true,
+					Description: "Public IPv6 address.",
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"domain_fronting": schema.ListNestedBlock{
+					Description: "Domain fronting entries.",
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"ip": schema.StringAttribute{
+								Optional: true, Computed: true,
+								Description: "Fronting IP address.",
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+							},
+							"port": schema.Int64Attribute{
+								Optional: true, Computed: true,
+								Description: "Fronting port.",
+								PlanModifiers: []planmodifier.Int64{
+									int64planmodifier.UseStateForUnknown(),
+								},
+							},
+							"proxy_protocol": schema.BoolAttribute{
+								Optional: true, Computed: true,
+								Description: "Enable PROXY protocol for this fronting entry.",
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.UseStateForUnknown(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -550,6 +676,8 @@ func expandSettingsFromModel(protocol string, m *InboundResourceModel) map[strin
 		return expandDokodemoInboundSettings(protocol, m.DokodemoSettings)
 	case "hysteria", "hysteria2":
 		return expandHysteriaInboundSettings(m.HysteriaSettings)
+	case "mtproto":
+		return expandMtprotoInboundSettings(m.MtprotoSettings)
 	default:
 		return nil
 	}
@@ -787,6 +915,64 @@ func expandHysteriaInboundSettings(m *InboundHysteriaSettingsModel) map[string]a
 	return out
 }
 
+func expandMtprotoInboundSettings(m *InboundMtprotoSettingsModel) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := map[string]any{}
+	if !m.FakeTlsDomain.IsNull() && !m.FakeTlsDomain.IsUnknown() {
+		out["fake_tls_domain"] = m.FakeTlsDomain.ValueString()
+	}
+	if !m.ProxyProtocolListener.IsNull() && !m.ProxyProtocolListener.IsUnknown() {
+		out["proxy_protocol_listener"] = m.ProxyProtocolListener.ValueBool()
+	}
+	if !m.PreferIp.IsNull() && !m.PreferIp.IsUnknown() {
+		out["prefer_ip"] = m.PreferIp.ValueString()
+	}
+	if !m.Debug.IsNull() && !m.Debug.IsUnknown() {
+		out["debug"] = m.Debug.ValueBool()
+	}
+	if len(m.DomainFronting) > 0 {
+		out["domain_fronting"] = expandMtprotoDomainFrontingFromModel(m.DomainFronting)
+	}
+	if !m.OutboundTag.IsNull() && !m.OutboundTag.IsUnknown() {
+		out["outbound_tag"] = m.OutboundTag.ValueString()
+	}
+	if !m.RouteThroughXray.IsNull() && !m.RouteThroughXray.IsUnknown() {
+		out["route_through_xray"] = m.RouteThroughXray.ValueBool()
+	}
+	if !m.RouteXrayPort.IsNull() && !m.RouteXrayPort.IsUnknown() {
+		out["route_xray_port"] = int(m.RouteXrayPort.ValueInt64())
+	}
+	if !m.PublicIpv4.IsNull() && !m.PublicIpv4.IsUnknown() {
+		out["public_ipv4"] = m.PublicIpv4.ValueString()
+	}
+	if !m.PublicIpv6.IsNull() && !m.PublicIpv6.IsUnknown() {
+		out["public_ipv6"] = m.PublicIpv6.ValueString()
+	}
+	return out
+}
+
+func expandMtprotoDomainFrontingFromModel(list []InboundMtprotoDomainFrontingModel) []any {
+	out := make([]any, 0, len(list))
+	for _, df := range list {
+		entry := map[string]any{}
+		if !df.IP.IsNull() && !df.IP.IsUnknown() {
+			entry["ip"] = df.IP.ValueString()
+		}
+		if !df.Port.IsNull() && !df.Port.IsUnknown() {
+			entry["port"] = int(df.Port.ValueInt64())
+		}
+		if !df.ProxyProtocol.IsNull() && !df.ProxyProtocol.IsUnknown() {
+			entry["proxy_protocol"] = df.ProxyProtocol.ValueBool()
+		}
+		if len(entry) > 0 {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
 func expandFallbacksFromModel(list []InboundFallbackModel) []any {
 	out := make([]any, 0, len(list))
 	for _, fb := range list {
@@ -880,6 +1066,8 @@ func flattenSettingsToModel(protocol string, data map[string]any, m *InboundReso
 		m.DokodemoSettings = flattenDokodemoInboundSettings(protocol, data)
 	case "hysteria", "hysteria2":
 		m.HysteriaSettings = flattenHysteriaInboundSettings(data)
+	case "mtproto":
+		m.MtprotoSettings = flattenMtprotoInboundSettings(data)
 	}
 }
 
@@ -1171,6 +1359,90 @@ func flattenHysteriaInboundSettings(data map[string]any) *InboundHysteriaSetting
 		m.Version = types.Int64Null()
 	}
 	return m
+}
+
+func flattenMtprotoInboundSettings(data map[string]any) *InboundMtprotoSettingsModel {
+	if len(data) == 0 {
+		return nil
+	}
+	m := &InboundMtprotoSettingsModel{}
+	if v, ok := data["fake_tls_domain"].(string); ok && v != "" {
+		m.FakeTlsDomain = types.StringValue(v)
+	} else {
+		m.FakeTlsDomain = types.StringNull()
+	}
+	if v, ok := data["proxy_protocol_listener"].(bool); ok {
+		m.ProxyProtocolListener = types.BoolValue(v)
+	} else {
+		m.ProxyProtocolListener = types.BoolNull()
+	}
+	if v, ok := data["prefer_ip"].(string); ok && v != "" {
+		m.PreferIp = types.StringValue(v)
+	} else {
+		m.PreferIp = types.StringNull()
+	}
+	if v, ok := data["debug"].(bool); ok {
+		m.Debug = types.BoolValue(v)
+	} else {
+		m.Debug = types.BoolNull()
+	}
+	if v, ok := data["domain_fronting"].([]any); ok && len(v) > 0 {
+		m.DomainFronting = flattenMtprotoDomainFrontingToModel(v)
+	}
+	if v, ok := data["outbound_tag"].(string); ok && v != "" {
+		m.OutboundTag = types.StringValue(v)
+	} else {
+		m.OutboundTag = types.StringNull()
+	}
+	if v, ok := data["route_through_xray"].(bool); ok {
+		m.RouteThroughXray = types.BoolValue(v)
+	} else {
+		m.RouteThroughXray = types.BoolNull()
+	}
+	if v, ok := data["route_xray_port"]; ok {
+		m.RouteXrayPort = types.Int64Value(int64(intValue(v)))
+	} else {
+		m.RouteXrayPort = types.Int64Null()
+	}
+	if v, ok := data["public_ipv4"].(string); ok && v != "" {
+		m.PublicIpv4 = types.StringValue(v)
+	} else {
+		m.PublicIpv4 = types.StringNull()
+	}
+	if v, ok := data["public_ipv6"].(string); ok && v != "" {
+		m.PublicIpv6 = types.StringValue(v)
+	} else {
+		m.PublicIpv6 = types.StringNull()
+	}
+	return m
+}
+
+func flattenMtprotoDomainFrontingToModel(list []any) []InboundMtprotoDomainFrontingModel {
+	out := make([]InboundMtprotoDomainFrontingModel, 0, len(list))
+	for _, item := range list {
+		raw, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		df := InboundMtprotoDomainFrontingModel{}
+		if v, ok := raw["ip"].(string); ok && v != "" {
+			df.IP = types.StringValue(v)
+		} else {
+			df.IP = types.StringNull()
+		}
+		if v, ok := raw["port"]; ok {
+			df.Port = types.Int64Value(int64(intValue(v)))
+		} else {
+			df.Port = types.Int64Null()
+		}
+		if v, ok := raw["proxy_protocol"].(bool); ok {
+			df.ProxyProtocol = types.BoolValue(v)
+		} else {
+			df.ProxyProtocol = types.BoolNull()
+		}
+		out = append(out, df)
+	}
+	return out
 }
 
 func flattenFallbacksToModel(list []any) []InboundFallbackModel {

--- a/provider/resource_inbound.go
+++ b/provider/resource_inbound.go
@@ -66,6 +66,7 @@ type InboundResourceModel struct {
 	WireguardSettings   *InboundWireguardSettingsModel   `tfsdk:"wireguard_settings"`
 	DokodemoSettings    *InboundDokodemoSettingsModel    `tfsdk:"dokodemo_settings"`
 	HysteriaSettings    *InboundHysteriaSettingsModel    `tfsdk:"hysteria_settings"`
+	MtprotoSettings     *InboundMtprotoSettingsModel     `tfsdk:"mtproto_settings"`
 
 	// Stream settings (typed block)
 	StreamSettings *InboundStreamSettingsModel `tfsdk:"stream_settings"`
@@ -741,6 +742,9 @@ func alignBlocksWithPlan(state *InboundResourceModel, plan *InboundResourceModel
 	}
 	if plan.HysteriaSettings == nil {
 		state.HysteriaSettings = nil
+	}
+	if plan.MtprotoSettings == nil {
+		state.MtprotoSettings = nil
 	}
 	if plan.StreamSettings == nil {
 		state.StreamSettings = nil

--- a/provider/settings.go
+++ b/provider/settings.go
@@ -151,6 +151,42 @@ func buildSettingsJSON(item map[string]any, protocol string) string {
 		}
 	}
 
+	// MTProto settings (3x-ui v3.3.0+)
+	if v, ok := item["fake_tls_domain"].(string); ok && v != "" {
+		payload["fakeTlsDomain"] = v
+	}
+	if v, ok := item["proxy_protocol_listener"]; ok {
+		payload["proxyProtocolListener"] = boolValue(v)
+	}
+	if v, ok := item["prefer_ip"].(string); ok && v != "" {
+		payload["preferIp"] = v
+	}
+	if v, ok := item["debug"]; ok {
+		payload["debug"] = boolValue(v)
+	}
+	if v, ok := item["domain_fronting"]; ok {
+		if list, ok := v.([]any); ok && len(list) > 0 {
+			payload["domainFronting"] = expandMtprotoDomainFronting(list)
+		}
+	}
+	if v, ok := item["outbound_tag"].(string); ok && v != "" {
+		payload["outboundTag"] = v
+	}
+	if v, ok := item["route_through_xray"]; ok {
+		payload["routeThroughXray"] = boolValue(v)
+	}
+	if v, ok := item["route_xray_port"]; ok {
+		if p := intValue(v); p != 0 {
+			payload["routeXrayPort"] = p
+		}
+	}
+	if v, ok := item["public_ipv4"].(string); ok && v != "" {
+		payload["publicIpv4"] = v
+	}
+	if v, ok := item["public_ipv6"].(string); ok && v != "" {
+		payload["publicIpv6"] = v
+	}
+
 	if len(payload) == 0 {
 		return "{}"
 	}
@@ -273,6 +309,38 @@ func flattenSettings(settings string, protocol string) ([]any, error) {
 		if v, ok := payload["clients"].([]any); ok && len(v) > 0 {
 			out["clients"] = v
 		}
+	}
+
+	// MTProto settings (3x-ui v3.3.0+)
+	if v, ok := payload["fakeTlsDomain"].(string); ok {
+		out["fake_tls_domain"] = v
+	}
+	if v, ok := payload["proxyProtocolListener"].(bool); ok {
+		out["proxy_protocol_listener"] = v
+	}
+	if v, ok := payload["preferIp"].(string); ok {
+		out["prefer_ip"] = v
+	}
+	if v, ok := payload["debug"].(bool); ok {
+		out["debug"] = v
+	}
+	if v, ok := payload["domainFronting"].([]any); ok {
+		out["domain_fronting"] = flattenMtprotoDomainFronting(v)
+	}
+	if v, ok := payload["outboundTag"].(string); ok {
+		out["outbound_tag"] = v
+	}
+	if v, ok := payload["routeThroughXray"].(bool); ok {
+		out["route_through_xray"] = v
+	}
+	if v, ok := payload["routeXrayPort"]; ok {
+		out["route_xray_port"] = intValue(v)
+	}
+	if v, ok := payload["publicIpv4"].(string); ok {
+		out["public_ipv4"] = v
+	}
+	if v, ok := payload["publicIpv6"].(string); ok {
+		out["public_ipv6"] = v
 	}
 	if len(out) == 0 {
 		return []any{}, nil
@@ -464,6 +532,54 @@ func flattenIntList(list []any) []int {
 	out := make([]int, 0, len(list))
 	for _, v := range list {
 		out = append(out, intValue(v))
+	}
+	return out
+}
+
+func expandMtprotoDomainFronting(list []any) []any {
+	out := make([]any, 0, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		entry := map[string]any{}
+		if v, ok := m["ip"].(string); ok && v != "" {
+			entry["ip"] = v
+		}
+		if v, ok := m["port"]; ok {
+			if p := intValue(v); p != 0 {
+				entry["port"] = p
+			}
+		}
+		if v, ok := m["proxy_protocol"]; ok {
+			entry["proxyProtocol"] = boolValue(v)
+		}
+		if len(entry) > 0 {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+func flattenMtprotoDomainFronting(list []any) []any {
+	out := make([]any, 0, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		entry := map[string]any{}
+		if v, ok := m["ip"].(string); ok {
+			entry["ip"] = v
+		}
+		if v, ok := m["port"]; ok {
+			entry["port"] = intValue(v)
+		}
+		if v, ok := m["proxyProtocol"].(bool); ok {
+			entry["proxy_protocol"] = v
+		}
+		out = append(out, entry)
 	}
 	return out
 }

--- a/provider/settings_expand_flatten_test.go
+++ b/provider/settings_expand_flatten_test.go
@@ -520,3 +520,116 @@ func TestFlattenSettingsToModel_TunnelProtocol(t *testing.T) {
 		t.Fatalf("unexpected allowed_network: %s", model.DokodemoSettings.AllowedNetwork.ValueString())
 	}
 }
+
+func TestExpandFlattenMtprotoSettingsModel_RoundTrip(t *testing.T) {
+	model := &InboundResourceModel{
+		MtprotoSettings: &InboundMtprotoSettingsModel{
+			FakeTlsDomain:         types.StringValue("bing.com"),
+			ProxyProtocolListener: types.BoolValue(true),
+			PreferIp:              types.StringValue("prefer-ipv6"),
+			Debug:                 types.BoolValue(false),
+			DomainFronting: []InboundMtprotoDomainFrontingModel{
+				{IP: types.StringValue("1.2.3.4"), Port: types.Int64Value(443), ProxyProtocol: types.BoolValue(true)},
+			},
+			OutboundTag:      types.StringValue("mt-out"),
+			RouteThroughXray: types.BoolValue(true),
+			RouteXrayPort:    types.Int64Value(1080),
+			PublicIpv4:       types.StringValue("203.0.113.1"),
+			PublicIpv6:       types.StringValue("2001:db8::1"),
+		},
+	}
+
+	// Expand typed model → untyped map
+	expanded := expandSettingsFromModel("mtproto", model)
+	if expanded == nil {
+		t.Fatal("expected non-nil result for mtproto protocol")
+	}
+	if expanded["fake_tls_domain"] != "bing.com" {
+		t.Fatalf("unexpected fake_tls_domain: %v", expanded["fake_tls_domain"])
+	}
+	if expanded["proxy_protocol_listener"] != true {
+		t.Fatalf("unexpected proxy_protocol_listener: %v", expanded["proxy_protocol_listener"])
+	}
+	if expanded["prefer_ip"] != "prefer-ipv6" {
+		t.Fatalf("unexpected prefer_ip: %v", expanded["prefer_ip"])
+	}
+	if expanded["outbound_tag"] != "mt-out" {
+		t.Fatalf("unexpected outbound_tag: %v", expanded["outbound_tag"])
+	}
+	if expanded["route_xray_port"] != 1080 {
+		t.Fatalf("unexpected route_xray_port: %v", expanded["route_xray_port"])
+	}
+
+	// Build JSON (snake → camelCase)
+	jsonStr := buildSettingsJSON(expanded, "mtproto")
+
+	// Flatten back (camelCase → snake)
+	flatMap, err := flattenSettingsToMap(jsonStr, "mtproto")
+	if err != nil {
+		t.Fatalf("flattenSettingsToMap error: %v", err)
+	}
+
+	result := &InboundResourceModel{}
+	flattenSettingsToModel("mtproto", flatMap, result)
+	if result.MtprotoSettings == nil {
+		t.Fatal("expected MtprotoSettings to be set")
+	}
+	if result.MtprotoSettings.FakeTlsDomain.ValueString() != "bing.com" {
+		t.Fatalf("unexpected fake_tls_domain: %s", result.MtprotoSettings.FakeTlsDomain.ValueString())
+	}
+	if !result.MtprotoSettings.ProxyProtocolListener.ValueBool() {
+		t.Fatalf("unexpected proxy_protocol_listener: %v", result.MtprotoSettings.ProxyProtocolListener.ValueBool())
+	}
+	if result.MtprotoSettings.PreferIp.ValueString() != "prefer-ipv6" {
+		t.Fatalf("unexpected prefer_ip: %s", result.MtprotoSettings.PreferIp.ValueString())
+	}
+	if result.MtprotoSettings.Debug.ValueBool() != false {
+		t.Fatalf("unexpected debug: %v", result.MtprotoSettings.Debug.ValueBool())
+	}
+	if len(result.MtprotoSettings.DomainFronting) != 1 {
+		t.Fatalf("expected 1 domain_fronting entry, got %d", len(result.MtprotoSettings.DomainFronting))
+	}
+	df := result.MtprotoSettings.DomainFronting[0]
+	if df.IP.ValueString() != "1.2.3.4" {
+		t.Fatalf("unexpected domain_fronting ip: %s", df.IP.ValueString())
+	}
+	if df.Port.ValueInt64() != 443 {
+		t.Fatalf("unexpected domain_fronting port: %d", df.Port.ValueInt64())
+	}
+	if !df.ProxyProtocol.ValueBool() {
+		t.Fatalf("unexpected domain_fronting proxy_protocol: %v", df.ProxyProtocol.ValueBool())
+	}
+	if result.MtprotoSettings.OutboundTag.ValueString() != "mt-out" {
+		t.Fatalf("unexpected outbound_tag: %s", result.MtprotoSettings.OutboundTag.ValueString())
+	}
+	if !result.MtprotoSettings.RouteThroughXray.ValueBool() {
+		t.Fatalf("unexpected route_through_xray: %v", result.MtprotoSettings.RouteThroughXray.ValueBool())
+	}
+	if result.MtprotoSettings.RouteXrayPort.ValueInt64() != 1080 {
+		t.Fatalf("unexpected route_xray_port: %d", result.MtprotoSettings.RouteXrayPort.ValueInt64())
+	}
+	if result.MtprotoSettings.PublicIpv4.ValueString() != "203.0.113.1" {
+		t.Fatalf("unexpected public_ipv4: %s", result.MtprotoSettings.PublicIpv4.ValueString())
+	}
+	if result.MtprotoSettings.PublicIpv6.ValueString() != "2001:db8::1" {
+		t.Fatalf("unexpected public_ipv6: %s", result.MtprotoSettings.PublicIpv6.ValueString())
+	}
+}
+
+func TestExpandSettingsFromModel_MtprotoNil(t *testing.T) {
+	model := &InboundResourceModel{
+		MtprotoSettings: nil,
+	}
+	result := expandSettingsFromModel("mtproto", model)
+	if result != nil {
+		t.Fatalf("expected nil for nil MtprotoSettings, got %v", result)
+	}
+}
+
+func TestFlattenSettingsToModel_MtprotoEmptyData(t *testing.T) {
+	model := &InboundResourceModel{}
+	flattenSettingsToModel("mtproto", map[string]any{}, model)
+	if model.MtprotoSettings != nil {
+		t.Fatal("expected nil MtprotoSettings for empty data")
+	}
+}

--- a/provider/validators.go
+++ b/provider/validators.go
@@ -74,7 +74,7 @@ func protocolValidators() []validator.String {
 			"vless", "vmess", "trojan", "shadowsocks",
 			"http", "socks", "mixed", "wireguard",
 			"dokodemo-door", "tunnel", "tun",
-			"hysteria", "hysteria2",
+			"hysteria", "hysteria2", "mtproto",
 		),
 	}
 }

--- a/provider/validators_test.go
+++ b/provider/validators_test.go
@@ -179,7 +179,7 @@ func TestProtocolValidators(t *testing.T) {
 		"vless", "vmess", "trojan", "shadowsocks",
 		"http", "socks", "mixed", "wireguard",
 		"dokodemo-door", "tunnel", "tun",
-		"hysteria", "hysteria2",
+		"hysteria", "hysteria2", "mtproto",
 	}
 	for _, val := range valid {
 		for _, vv := range v {


### PR DESCRIPTION
Closes #335

Adds typed `mtproto_settings` block:
- fakeTlsDomain, proxyProtocolListener, preferIp, debug
- domainFronting nested block (ip/port/proxyProtocol)
- outboundTag, routeThroughXray, routeXrayPort
- publicIpv4, publicIpv6
- expand/flatten round-trip unit tests