### PR TITLE
docs: fix README resource table, SECURITY.md WO table, add 6 missing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Full documentation is available on the [Terraform Registry](https://registry.ter
 | `threexui_panel_user` | Admin credentials |
 | `threexui_panel_telegram` | Telegram bot integration |
 | `threexui_panel_email` | SMTP/email notifications (v3.4.0+) |
+| `threexui_host_group` | Host group routing (multi-host per inbound) |
 | `threexui_panel_subscription` | Subscription service settings |
 | `threexui_xray_basics` | Basic Xray config (log, policy, api, stats) |
 | `threexui_xray_dns` | DNS servers and hosts |
@@ -154,6 +155,7 @@ Full documentation is available on the [Terraform Registry](https://registry.ter
 | `threexui_xray_balancers` | Load balancers |
 | `threexui_xray_reverse` | Reverse proxy (bridges, portals) |
 | `threexui_xray_outbounds` | Outbound connections |
+| `threexui_xray_observatory` | Xray Observatory / BurstObservatory config |
 | `threexui_xray_version` | Installed Xray core version |
 
 ### Data Sources

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,7 @@ Starting with provider v3.13.0, resources that manage secrets offer write-only (
 | `threexui_panel_general` | `ldap_password_wo` | `ldap_password_wo_version` |
 | `threexui_panel_email` | `smtp_password_wo` | `smtp_password_wo_version` |
 | `threexui_node` | `api_token_wo`, `pinned_cert_sha256_wo` | `api_token_wo_version`, `pinned_cert_sha256_wo_version` |
+| `threexui_inbound_client` | `password_wo`, `secret_wo` | `password_wo_version`, `secret_wo_version` |
 
 ### How it works
 

--- a/examples/host-group/main.tf
+++ b/examples/host-group/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "https://panel.example.com:2053"
+  username = "admin"
+  password = "admin"
+}
+
+# Create a VLESS inbound first
+resource "threexui_inbound" "vless" {
+  port     = 443
+  protocol = "vless"
+  enable   = true
+  remark   = "VLESS Reality"
+}
+
+# Host group routing traffic to multiple hosts through the inbound
+resource "threexui_host_group" "cdn" {
+  remark      = "CDN Rotation"
+  hosts       = ["cdn1.example.com", "cdn2.example.com"]
+  inbound_ids = [threexui_inbound.vless.id]
+  sort_order  = 1
+  tags        = ["production", "cdn"]
+}

--- a/examples/node/main.tf
+++ b/examples/node/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "https://central.example.com:2053"
+  username = "admin"
+  password = "admin"
+}
+
+# Register a remote 3x-ui node in the central panel's cluster
+resource "threexui_node" "de_fra_1" {
+  name    = "de-fra-1"
+  address = "node1.example.com"
+  port    = 2053
+  scheme  = "https"
+
+  remark = "Frankfurt edge node"
+
+  # API token for inter-node communication (sensitive)
+  api_token = "node-api-token-secret"
+
+  enable = true
+
+  # Sync only selected inbounds to this node
+  inbound_sync_mode = "selected"
+  inbound_tags      = ["eu", "vless"]
+
+  outbound_tag = "proxy-out"
+}

--- a/examples/observatory/main.tf
+++ b/examples/observatory/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "https://panel.example.com:2053"
+  username = "admin"
+  password = "admin"
+}
+
+# Configure Xray Observatory to monitor outbound health.
+# The panel stores this as part of the Xray template config.
+resource "threexui_xray_observatory" "main" {
+  observer {
+    subject_selector = ["outbound"]
+    probe_url        = "https://www.google.com/generate_204"
+    probe_interval   = "30s"
+  }
+}

--- a/examples/panel-email/main.tf
+++ b/examples/panel-email/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "https://panel.example.com:2053"
+  username = "admin"
+  password = "admin"
+}
+
+# Configure SMTP email notifications (3x-ui v3.4.0+)
+resource "threexui_panel_email" "notifications" {
+  smtp_host     = "smtp.gmail.com"
+  smtp_port     = 587
+  smtp_username = "alerts@example.com"
+  smtp_password = "app-specific-password"
+  from_address  = "alerts@example.com"
+  notify_on     = ["traffic_limit", "expiry", "login"]
+}

--- a/examples/panel-user/main.tf
+++ b/examples/panel-user/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "https://panel.example.com:2053"
+  username = "admin"
+  password = "admin"
+}
+
+# Rotate the panel admin credentials.
+# The provider uses the current credentials from provider config to authenticate,
+# then updates the panel user to the new credentials.
+resource "threexui_panel_user" "admin" {
+  username = "admin"
+  password = "new-secure-password-2024"
+}

--- a/examples/xray-version/main.tf
+++ b/examples/xray-version/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    threexui = {
+      source = "batonogov/threexui"
+    }
+  }
+}
+
+provider "threexui" {
+  endpoint = "https://panel.example.com:2053"
+  username = "admin"
+  password = "admin"
+}
+
+# Pin a specific Xray core version.
+# The provider calls InstallXray and polls until the panel reports
+# the requested version. Delete is a no-op (does not revert the version).
+resource "threexui_xray_version" "pinned" {
+  version = "v25.6.6"
+}


### PR DESCRIPTION
## What

Closes #369, closes #370, closes #371.

### #370 — README resource table
Add two missing resources:
- `threexui_host_group` — Host group routing
- `threexui_xray_observatory` — Xray Observatory / BurstObservatory

### #371 — SECURITY.md write-only table
Add missing row:
- `threexui_inbound_client` — `password_wo`, `secret_wo` / `password_wo_version`, `secret_wo_version`

### #369 — Example .tf files
Add examples for 6 resources that had none:

| Resource | Example file |
|---|---|
| `threexui_host_group` | `examples/host-group/main.tf` |
| `threexui_node` | `examples/node/main.tf` |
| `threexui_panel_email` | `examples/panel-email/main.tf` |
| `threexui_panel_user` | `examples/panel-user/main.tf` |
| `threexui_xray_observatory` | `examples/observatory/main.tf` |
| `threexui_xray_version` | `examples/xray-version/main.tf` |

## Verification
Pure docs — no code changes, no CI impact.