### PR TITLE
chore: ignore .pine/ and .pi-subagents/ agent artifact dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ example2/
 .DS_Store
 .cache
 docs/superpowers/
+.pine/
+.pi-subagents/


### PR DESCRIPTION
## What & why

`.pi/` is already ignored in `.gitignore`, but two sibling directories used by local agent tooling are not:

- `.pine/`
- `.pi-subagents/`

These hold scratch artifacts from Pi/subagents tooling and should never be committed. Add them to `.gitignore` for consistency with the existing `.pi/` entry.

## Changes
- `.gitignore`: add `.pine/` and `.pi-subagents/`

## Notes
- PR #350 (audit easy-wins) was already merged into `main`; this opens a **separate** small PR for the remaining uncommitted `.gitignore` change.
- No code changes — no tests affected.