### PR TITLE
fix: keep omitted xray basics log absent

### DIFF
--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -48,6 +48,27 @@ func TestAccXrayBasics(t *testing.T) {
 	})
 }
 
+func TestAccXrayBasicsEmpty(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + testAccXrayBasicsEmptyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_xray_basics.test", "id", "xray_basics"),
+					resource.TestCheckResourceAttr("threexui_xray_basics.test", "log.#", "0"),
+				),
+			},
+			{
+				Config:             testAccProviderConfig() + testAccXrayBasicsEmptyConfig(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccXrayDNS(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -513,6 +534,12 @@ resource "threexui_xray_basics" "test" {
 
   stats {}
 }
+`
+}
+
+func testAccXrayBasicsEmptyConfig() string {
+	return `
+resource "threexui_xray_basics" "test" {}
 `
 }
 

--- a/provider/xray_basics_schema.go
+++ b/provider/xray_basics_schema.go
@@ -282,6 +282,9 @@ func xrayBasicsSchema() schema.Schema {
 // ---------------------------------------------------------------------------
 
 func alignBasicsBlocksWithPlan(state, plan *XrayBasicsModel) {
+	if len(plan.Log) == 0 {
+		state.Log = nil
+	}
 	if len(plan.Policy) == 0 {
 		state.Policy = nil
 	} else {

--- a/provider/xray_basics_test.go
+++ b/provider/xray_basics_test.go
@@ -143,6 +143,19 @@ func TestExtractXraySectionIncludesEnv(t *testing.T) {
 	}
 }
 
+func TestAlignBasicsBlocksWithPlanClearsLog(t *testing.T) {
+	state := &XrayBasicsModel{
+		Log: []XrayBasicsLog{{Loglevel: types.StringValue("warning")}},
+	}
+	plan := &XrayBasicsModel{}
+
+	alignBasicsBlocksWithPlan(state, plan)
+
+	if state.Log != nil {
+		t.Fatalf("expected state.Log to be nil after align (plan has no log), got %v", state.Log)
+	}
+}
+
 // TestAlignBasicsBlocksWithPlanClearsEnv verifies the drift-prevention path:
 // when the plan has no env block but the state does, alignBasicsBlocksWithPlan
 // nils out state.Env so Terraform does not raise "was absent, but now present".


### PR DESCRIPTION
## Summary

- keep the `log` block absent in Terraform state when it was omitted from `threexui_xray_basics` configuration
- extend the existing plan-alignment logic to cover the last optional top-level basics block
- add unit and live acceptance regressions for an empty basics resource

## Problem

3x-ui supplies a default `log` object even when configuration omits the block. The provider already aligned other omitted optional basics blocks with the plan, but left `state.Log` populated. Terraform therefore rejected an otherwise successful create with:

```text
.log: block count changed from 0 to 1
```

## Test plan

- [x] focused unit regression (RED before fix, GREEN after fix)
- [x] related Xray basics/alignment tests
- [x] `TestAccXrayBasicsEmpty` against 3x-ui v3.6.0
- [x] `go test ./... -short -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [ ] GitHub Actions and Codecov

Fixes #208
