### PR TITLE
fix: default balancer baselines to typed null

### DIFF
--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -364,6 +364,36 @@ func TestAccXrayBalancers(t *testing.T) {
 	})
 }
 
+func TestAccXrayBalancersBaselinesPresence(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + testAccXrayBalancersBaselinesConfig(false),
+				Check: resource.TestCheckResourceAttr(
+					"threexui_xray_balancers.baselines",
+					"balancer.0.strategy.0.settings.0.baselines.#",
+					"0",
+				),
+			},
+			{
+				Config: testAccProviderConfig() + testAccXrayBalancersBaselinesConfig(true),
+				Check: resource.TestCheckResourceAttr(
+					"threexui_xray_balancers.baselines",
+					"balancer.0.strategy.0.settings.0.baselines.#",
+					"0",
+				),
+			},
+			{
+				Config:             testAccProviderConfig() + testAccXrayBalancersBaselinesConfig(true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccXrayReverse(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -612,6 +642,29 @@ resource "threexui_xray_balancers" "test" {
   }
 }
 `
+}
+
+func testAccXrayBalancersBaselinesConfig(explicitEmpty bool) string {
+	baselines := ""
+	if explicitEmpty {
+		baselines = "        baselines = []\n"
+	}
+	return fmt.Sprintf(`
+resource "threexui_xray_balancers" "baselines" {
+  balancer {
+    tag      = "review-baselines"
+    selector = ["direct"]
+
+    strategy {
+      type = "leastPing"
+
+      settings {
+        expected = 2
+%s      }
+    }
+  }
+}
+`, baselines)
 }
 
 func testAccXrayReverseConfig() string {

--- a/provider/xray_balancers_schema.go
+++ b/provider/xray_balancers_schema.go
@@ -399,9 +399,10 @@ func expandBalancerStrategySettings(settings []XrayBalancerStrategySettings) map
 				bl = append(bl, sv.ValueString())
 			}
 		}
-		if len(bl) > 0 {
-			out["baselines"] = bl
-		}
+		// Preserve an explicitly configured empty list. Omitting this key would
+		// make the panel read-back indistinguishable from a null value and cause
+		// Terraform to reject the post-apply state.
+		out["baselines"] = bl
 	}
 	if len(st.Costs) > 0 {
 		costs := make([]any, 0, len(st.Costs))
@@ -524,7 +525,7 @@ func flattenBalancerStrategySettings(in map[string]any) []XrayBalancerStrategySe
 			st.Tolerance = types.Float64Value(f)
 		}
 	}
-	if v, ok := settingsRaw["baselines"].([]any); ok && len(v) > 0 {
+	if v, ok := settingsRaw["baselines"].([]any); ok {
 		vals := make([]attr.Value, 0, len(v))
 		for _, b := range v {
 			if s, ok := b.(string); ok {

--- a/provider/xray_balancers_schema.go
+++ b/provider/xray_balancers_schema.go
@@ -503,7 +503,9 @@ func flattenBalancerStrategySettings(in map[string]any) []XrayBalancerStrategySe
 	if !ok || len(settingsRaw) == 0 {
 		return nil
 	}
-	st := XrayBalancerStrategySettings{}
+	st := XrayBalancerStrategySettings{
+		Baselines: types.ListNull(types.StringType),
+	}
 	if v, ok := settingsRaw["expected"]; ok {
 		switch n := v.(type) {
 		case float64:

--- a/provider/xray_balancers_test.go
+++ b/provider/xray_balancers_test.go
@@ -247,27 +247,49 @@ func TestFlattenBalancerStrategySettingsIntExpected(t *testing.T) {
 	}
 }
 
-func TestFlattenBalancerStrategySettingsBaselinesDefaultToTypedNull(t *testing.T) {
-	tests := map[string]map[string]any{
-		"absent": {"expected": 2},
-		"empty":  {"expected": 2, "baselines": []any{}},
+func TestFlattenBalancerStrategySettingsBaselinesPreservesPresence(t *testing.T) {
+	tests := map[string]struct {
+		settings map[string]any
+		wantNull bool
+	}{
+		"absent": {settings: map[string]any{"expected": 2}, wantNull: true},
+		"empty":  {settings: map[string]any{"expected": 2, "baselines": []any{}}, wantNull: false},
 	}
 
-	for name, settings := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			res := flattenBalancerStrategySettings(map[string]any{"settings": settings})
+			res := flattenBalancerStrategySettings(map[string]any{"settings": tc.settings})
 			if len(res) != 1 {
 				t.Fatalf("expected 1 settings block, got %d", len(res))
 			}
 
 			baselines := res[0].Baselines
-			if !baselines.IsNull() {
-				t.Fatalf("expected baselines to be null, got %s", baselines)
+			if baselines.IsNull() != tc.wantNull {
+				t.Fatalf("baselines null = %t, want %t: %s", baselines.IsNull(), tc.wantNull, baselines)
 			}
 			if got := baselines.ElementType(context.Background()); !got.Equal(types.StringType) {
 				t.Fatalf("expected baselines element type %s, got %s", types.StringType, got)
 			}
+			if !tc.wantNull && len(baselines.Elements()) != 0 {
+				t.Fatalf("expected explicit empty baselines, got %s", baselines)
+			}
 		})
+	}
+}
+
+func TestExpandBalancerStrategySettingsPreservesExplicitEmptyBaselines(t *testing.T) {
+	settings := []XrayBalancerStrategySettings{{
+		Expected:  types.Int64Value(2),
+		Baselines: types.ListValueMust(types.StringType, []attr.Value{}),
+	}}
+
+	got := expandBalancerStrategySettings(settings)
+	baselines, ok := got["baselines"].([]any)
+	if !ok {
+		t.Fatalf("expected explicit baselines array on wire, got %#v", got["baselines"])
+	}
+	if len(baselines) != 0 {
+		t.Fatalf("expected empty baselines array, got %#v", baselines)
 	}
 }
 

--- a/provider/xray_balancers_test.go
+++ b/provider/xray_balancers_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -243,6 +244,30 @@ func TestFlattenBalancerStrategySettingsIntExpected(t *testing.T) {
 	}
 	if len(st.Costs) != 1 || !st.Costs[0].Regexp.ValueBool() {
 		t.Fatalf("expected 1 cost with regexp=true, got %+v", st.Costs)
+	}
+}
+
+func TestFlattenBalancerStrategySettingsBaselinesDefaultToTypedNull(t *testing.T) {
+	tests := map[string]map[string]any{
+		"absent": {"expected": 2},
+		"empty":  {"expected": 2, "baselines": []any{}},
+	}
+
+	for name, settings := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := flattenBalancerStrategySettings(map[string]any{"settings": settings})
+			if len(res) != 1 {
+				t.Fatalf("expected 1 settings block, got %d", len(res))
+			}
+
+			baselines := res[0].Baselines
+			if !baselines.IsNull() {
+				t.Fatalf("expected baselines to be null, got %s", baselines)
+			}
+			if got := baselines.ElementType(context.Background()); !got.Equal(types.StringType) {
+				t.Fatalf("expected baselines element type %s, got %s", types.StringType, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- initialize omitted balancer `baselines` as a typed null `list(string)`
- prevent post-apply state conversion failures for strategy settings that omit `baselines`
- preserve an explicitly configured empty `baselines = []` through the panel round trip
- add focused unit and live acceptance coverage for absent versus explicit-empty values

## Problem

`flattenBalancerStrategySettings` left `Baselines` as the zero value of `types.List` when the remote strategy settings omitted the field. That value has no element type, so setting Terraform state failed after the panel write with a `Value Conversion Error` instead of producing a null `list(string)`.

## Test plan

- [x] focused regression (nil element type panic before fix, GREEN after fix)
- [x] related balancer tests
- [x] `TestAccXrayBalancersBaselinesPresence` against 3x-ui v3.6.0
  - [x] omitted `baselines`
  - [x] explicit `baselines = []`
  - [x] no-op follow-up plan
- [x] `go test ./... -short -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [x] GitHub Actions and Codecov

Fixes #417
