### PR TITLE
fix(node): handle unknown inbound tags in planning

### DIFF
--- a/provider/resource_node.go
+++ b/provider/resource_node.go
@@ -62,23 +62,22 @@ func (r *NodeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
 		return
 	}
-	var plan, state NodeResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	var planAPITokenVersion, stateAPITokenVersion types.Int64
+	var planPinnedCertVersion, statePinnedCertVersion types.Int64
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("api_token_wo_version"), &planAPITokenVersion)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("api_token_wo_version"), &stateAPITokenVersion)...)
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("pinned_cert_sha256_wo_version"), &planPinnedCertVersion)...)
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("pinned_cert_sha256_wo_version"), &statePinnedCertVersion)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	changed := false
-	if woVersionTriggered(plan.ApiTokenWOVersion, state.ApiTokenWOVersion) {
-		plan.ApiToken = types.StringUnknown()
-		changed = true
+
+	if woVersionTriggered(planAPITokenVersion, stateAPITokenVersion) {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("api_token"), types.StringUnknown())...)
 	}
-	if woVersionTriggered(plan.PinnedCertSha256WOVersion, state.PinnedCertSha256WOVersion) {
-		plan.PinnedCertSha256 = types.StringUnknown()
-		changed = true
-	}
-	if changed {
-		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	if woVersionTriggered(planPinnedCertVersion, statePinnedCertVersion) {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("pinned_cert_sha256"), types.StringUnknown())...)
 	}
 }
 

--- a/provider/resource_node_test.go
+++ b/provider/resource_node_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -1044,6 +1045,45 @@ func TestNodeResource_ModifyPlan_BothSecretsTriggered(t *testing.T) {
 	}
 	if !out.PinnedCertSha256.IsUnknown() {
 		t.Fatalf("expected pinned_cert_sha256 marked Unknown on simultaneous rotation, got %v", out.PinnedCertSha256)
+	}
+}
+
+func TestNodeResource_ModifyPlan_UnknownInboundTagsWithBothSecretsTriggered(t *testing.T) {
+	r := &NodeResource{}
+	ctx := context.Background()
+	plan, st := modifyPlanFixture(t, r, 2, 2, 1, 1)
+
+	diags := plan.SetAttribute(ctx, path.Root("inbound_tags"), types.ListUnknown(types.StringType))
+	if diags.HasError() {
+		t.Fatalf("failed to build unknown inbound_tags plan: %v", diags)
+	}
+
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, State: st}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ModifyPlan must accept an unknown inbound_tags list: %v", resp.Diagnostics)
+	}
+
+	var inboundTags types.List
+	resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root("inbound_tags"), &inboundTags)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("failed to read inbound_tags from the modified plan: %v", resp.Diagnostics)
+	}
+	if !inboundTags.IsUnknown() {
+		t.Fatalf("inbound_tags must remain unknown, got %v", inboundTags)
+	}
+
+	var apiToken, pinnedCertSha256 types.String
+	resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root("api_token"), &apiToken)...)
+	resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root("pinned_cert_sha256"), &pinnedCertSha256)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("failed to read rotated secrets from the modified plan: %v", resp.Diagnostics)
+	}
+	if !apiToken.IsUnknown() {
+		t.Fatalf("api_token must be unknown on simultaneous rotation, got %v", apiToken)
+	}
+	if !pinnedCertSha256.IsUnknown() {
+		t.Fatalf("pinned_cert_sha256 must be unknown on simultaneous rotation, got %v", pinnedCertSha256)
 	}
 }
 

--- a/provider/resource_node_test.go
+++ b/provider/resource_node_test.go
@@ -980,7 +980,7 @@ func setPlanValue(t *testing.T, r *NodeResource, plan tfsdk.Plan, key, val strin
 
 // modifyPlanFixture builds a Plan/State pair for ModifyPlan tests, with the
 // given *_wo_version values for both secrets and a concrete api_token.
-func modifyPlanFixture(t *testing.T, r *NodeResource, apiWOVer, pinWOVer, stateAPIWOVer, statePinWOVer int64) (tfsdk.Plan, tfsdk.State) {
+func modifyPlanFixture(t *testing.T, r *NodeResource, apiWOVer, pinWOVer int64) (tfsdk.Plan, tfsdk.State) {
 	t.Helper()
 	var schemaResp resource.SchemaResponse
 	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
@@ -1016,7 +1016,7 @@ func modifyPlanFixture(t *testing.T, r *NodeResource, apiWOVer, pinWOVer, stateA
 	}
 
 	plan := build(apiWOVer, pinWOVer)
-	state := build(stateAPIWOVer, statePinWOVer)
+	state := build(1, 1)
 	return plan, tfsdk.State(state)
 }
 
@@ -1027,7 +1027,7 @@ func modifyPlanFixture(t *testing.T, r *NodeResource, apiWOVer, pinWOVer, stateA
 func TestNodeResource_ModifyPlan_BothSecretsTriggered(t *testing.T) {
 	r := &NodeResource{}
 	ctx := context.Background()
-	plan, st := modifyPlanFixture(t, r, 2, 2, 1, 1) // both bumped
+	plan, st := modifyPlanFixture(t, r, 2, 2) // both bumped
 
 	var schemaResp resource.SchemaResponse
 	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
@@ -1051,7 +1051,7 @@ func TestNodeResource_ModifyPlan_BothSecretsTriggered(t *testing.T) {
 func TestNodeResource_ModifyPlan_UnknownInboundTagsWithBothSecretsTriggered(t *testing.T) {
 	r := &NodeResource{}
 	ctx := context.Background()
-	plan, st := modifyPlanFixture(t, r, 2, 2, 1, 1)
+	plan, st := modifyPlanFixture(t, r, 2, 2)
 
 	diags := plan.SetAttribute(ctx, path.Root("inbound_tags"), types.ListUnknown(types.StringType))
 	if diags.HasError() {
@@ -1091,7 +1091,7 @@ func TestNodeResource_ModifyPlan_SingleSecretTriggered(t *testing.T) {
 	r := &NodeResource{}
 	ctx := context.Background()
 	// Only api_token_wo_version bumps; pinned stays the same.
-	plan, st := modifyPlanFixture(t, r, 2, 1, 1, 1)
+	plan, st := modifyPlanFixture(t, r, 2, 1)
 
 	var schemaResp resource.SchemaResponse
 	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)
@@ -1116,7 +1116,7 @@ func TestNodeResource_ModifyPlan_NoTrigger(t *testing.T) {
 	r := &NodeResource{}
 	ctx := context.Background()
 	// No version change at all — ModifyPlan must be a no-op.
-	plan, st := modifyPlanFixture(t, r, 1, 1, 1, 1)
+	plan, st := modifyPlanFixture(t, r, 1, 1)
 
 	var schemaResp resource.SchemaResponse
 	r.Schema(context.Background(), resource.SchemaRequest{}, &schemaResp)


### PR DESCRIPTION
## Summary

- avoid decoding the entire node plan/state in `ModifyPlan`
- read only the two write-only secret version attributes and update only their corresponding plain secret attributes
- preserve simultaneous rotation of both node secrets while allowing an unknown `inbound_tags` collection

## Problem

`NodeResource.ModifyPlan` decoded `NodeResourceModel`, whose `inbound_tags` field is a native `[]types.String`. A valid unknown whole collection cannot be represented by that native slice, so node updates failed during planning with a framework `Value Conversion Error` before any API call.

## Test plan

- [x] focused unknown-collection regression (RED before fix, GREEN after fix)
- [x] simultaneous `api_token` and `pinned_cert_sha256` rotation coverage
- [x] related node ModifyPlan tests
- [x] `golangci-lint v2.11.3` (`0 issues`)
- [x] `go test ./... -short -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [x] GitHub Actions and Codecov

Fixes #421
