### PR TITLE
fix: keep DNS server fields with configured entries

### DIFF
--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -93,6 +93,91 @@ func TestAccXrayDNS(t *testing.T) {
 	})
 }
 
+func testAccCheckXrayConfigDNSServersNoStaleFields(dataSourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("data source %s not found in state", dataSourceName)
+		}
+		var cfg map[string]any
+		if err := json.Unmarshal([]byte(rs.Primary.Attributes["json"]), &cfg); err != nil {
+			return fmt.Errorf("cannot parse xray config JSON: %w", err)
+		}
+		dns, ok := cfg["dns"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("xray config has no dns section")
+		}
+		servers, ok := dns["servers"].([]any)
+		if !ok || len(servers) != 2 {
+			return fmt.Errorf("expected 2 remote DNS servers, got %v", dns["servers"])
+		}
+		switch sparse := servers[0].(type) {
+		case string:
+			if sparse != "1.1.1.1" {
+				return fmt.Errorf("remote DNS server 0 has unexpected address %q", sparse)
+			}
+		case map[string]any:
+			if sparse["address"] != "1.1.1.1" {
+				return fmt.Errorf("remote DNS server 0 has unexpected address %v", sparse["address"])
+			}
+			for _, field := range []string{"port", "domains", "skipFallback"} {
+				if value, exists := sparse[field]; exists {
+					return fmt.Errorf("remote DNS server 0 must not have stale %s, got %v", field, value)
+				}
+			}
+		default:
+			return fmt.Errorf("remote DNS server 0 has unexpected type %T", servers[0])
+		}
+		rich, ok := servers[1].(map[string]any)
+		if !ok {
+			return fmt.Errorf("remote DNS server 1 has unexpected type %T", servers[1])
+		}
+		if rich["address"] != "8.8.8.8" || intValue(rich["port"]) != 5353 || rich["skipFallback"] != true {
+			return fmt.Errorf("remote DNS server 1 lost configured fields: %v", rich)
+		}
+		return nil
+	}
+}
+
+func TestAccXrayDNSServersReorderNoFieldBleed(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + testAccXrayDNSReorderConfigStep1(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.address", "8.8.8.8"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.port", "5353"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.domains.0", "geosite:cn"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.skip_fallback", "true"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.address", "1.1.1.1"),
+				),
+			},
+			{
+				Config: testAccProviderConfig() + testAccXrayDNSReorderConfigStep2(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.#", "2"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.address", "1.1.1.1"),
+					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.port"),
+					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.domains"),
+					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.skip_fallback"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.address", "8.8.8.8"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.port", "5353"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.domains.0", "geosite:cn"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.skip_fallback", "true"),
+					testAccCheckXrayConfigDNSServersNoStaleFields("data.threexui_xray_config.current"),
+				),
+			},
+			{
+				Config:             testAccProviderConfig() + testAccXrayDNSReorderConfigStep2(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccXrayRouting(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -546,6 +631,44 @@ resource "threexui_xray_dns" "test" {
   server {
     address = "1.1.1.1"
   }
+}
+`
+}
+
+func testAccXrayDNSReorderConfigStep1() string {
+	return `
+resource "threexui_xray_dns" "test" {
+  server {
+    address       = "8.8.8.8"
+    port          = 5353
+    domains       = ["geosite:cn"]
+    skip_fallback = true
+  }
+
+  server {
+    address = "1.1.1.1"
+  }
+}
+`
+}
+
+func testAccXrayDNSReorderConfigStep2() string {
+	return `
+resource "threexui_xray_dns" "test" {
+  server {
+    address = "1.1.1.1"
+  }
+
+  server {
+    address       = "8.8.8.8"
+    port          = 5353
+    domains       = ["geosite:cn"]
+    skip_fallback = true
+  }
+}
+
+data "threexui_xray_config" "current" {
+  depends_on = [threexui_xray_dns.test]
 }
 `
 }

--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -120,7 +120,10 @@ func testAccCheckXrayConfigDNSServersNoStaleFields(dataSourceName string) resour
 			if sparse["address"] != "1.1.1.1" {
 				return fmt.Errorf("remote DNS server 0 has unexpected address %v", sparse["address"])
 			}
-			for _, field := range []string{"port", "domains", "skipFallback"} {
+			for _, field := range []string{
+				"port", "domains", "expectedIPs", "unexpectedIPs", "skipFallback",
+				"queryStrategy", "disableCache", "finalQuery",
+			} {
 				if value, exists := sparse[field]; exists {
 					return fmt.Errorf("remote DNS server 0 must not have stale %s, got %v", field, value)
 				}
@@ -132,8 +135,16 @@ func testAccCheckXrayConfigDNSServersNoStaleFields(dataSourceName string) resour
 		if !ok {
 			return fmt.Errorf("remote DNS server 1 has unexpected type %T", servers[1])
 		}
-		if rich["address"] != "8.8.8.8" || intValue(rich["port"]) != 5353 || rich["skipFallback"] != true {
+		if rich["address"] != "8.8.8.8" || intValue(rich["port"]) != 5353 ||
+			rich["skipFallback"] != true || rich["queryStrategy"] != "UseIPv4" ||
+			rich["disableCache"] != true || rich["finalQuery"] != true {
 			return fmt.Errorf("remote DNS server 1 lost configured fields: %v", rich)
+		}
+		for _, field := range []string{"domains", "expectedIPs", "unexpectedIPs"} {
+			values, ok := rich[field].([]any)
+			if !ok || len(values) != 1 {
+				return fmt.Errorf("remote DNS server 1 lost configured %s: field=%v server=%v", field, rich[field], rich)
+			}
 		}
 		return nil
 	}
@@ -150,7 +161,12 @@ func TestAccXrayDNSServersReorderNoFieldBleed(t *testing.T) {
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.address", "8.8.8.8"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.port", "5353"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.domains.0", "geosite:cn"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.expect_ips.0", "geoip:cn"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.unexpected_ips.0", "geoip:private"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.skip_fallback", "true"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.query_strategy", "UseIPv4"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.disable_cache", "true"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.final_query", "true"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.address", "1.1.1.1"),
 				),
 			},
@@ -161,11 +177,21 @@ func TestAccXrayDNSServersReorderNoFieldBleed(t *testing.T) {
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.0.address", "1.1.1.1"),
 					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.port"),
 					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.domains"),
+					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.expect_ips"),
+					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.unexpected_ips"),
 					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.skip_fallback"),
+					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.query_strategy"),
+					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.disable_cache"),
+					resource.TestCheckNoResourceAttr("threexui_xray_dns.test", "server.0.final_query"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.address", "8.8.8.8"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.port", "5353"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.domains.0", "geosite:cn"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.expect_ips.0", "geoip:cn"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.unexpected_ips.0", "geoip:private"),
 					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.skip_fallback", "true"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.query_strategy", "UseIPv4"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.disable_cache", "true"),
+					resource.TestCheckResourceAttr("threexui_xray_dns.test", "server.1.final_query", "true"),
 					testAccCheckXrayConfigDNSServersNoStaleFields("data.threexui_xray_config.current"),
 				),
 			},
@@ -639,10 +665,15 @@ func testAccXrayDNSReorderConfigStep1() string {
 	return `
 resource "threexui_xray_dns" "test" {
   server {
-    address       = "8.8.8.8"
-    port          = 5353
-    domains       = ["geosite:cn"]
-    skip_fallback = true
+    address        = "8.8.8.8"
+    port           = 5353
+    domains        = ["geosite:cn"]
+    expect_ips     = ["geoip:cn"]
+    unexpected_ips = ["geoip:private"]
+    skip_fallback  = true
+    query_strategy = "UseIPv4"
+    disable_cache  = true
+    final_query    = true
   }
 
   server {
@@ -660,10 +691,15 @@ resource "threexui_xray_dns" "test" {
   }
 
   server {
-    address       = "8.8.8.8"
-    port          = 5353
-    domains       = ["geosite:cn"]
-    skip_fallback = true
+    address        = "8.8.8.8"
+    port           = 5353
+    domains        = ["geosite:cn"]
+    expect_ips     = ["geoip:cn"]
+    unexpected_ips = ["geoip:private"]
+    skip_fallback  = true
+    query_strategy = "UseIPv4"
+    disable_cache  = true
+    final_query    = true
   }
 }
 

--- a/provider/resource_xray_settings.go
+++ b/provider/resource_xray_settings.go
@@ -225,6 +225,7 @@ func (r *XrayBasicsResource) ImportState(ctx context.Context, _ resource.ImportS
 var (
 	_ resource.Resource                = &XrayDNSResource{}
 	_ resource.ResourceWithImportState = &XrayDNSResource{}
+	_ resource.ResourceWithModifyPlan  = &XrayDNSResource{}
 )
 
 type XrayDNSResource struct{ client *Client }
@@ -315,6 +316,39 @@ func (r *XrayDNSResource) ImportState(ctx context.Context, _ resource.ImportStat
 	}
 	state := flattenXrayDNS(flat)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+// ModifyPlan keeps configured DNS server blocks authoritative. Nested
+// Optional+Computed attributes use UseStateForUnknown, which otherwise carries
+// values from the prior occupant of the same list index when servers are
+// reordered. Read the collection as types.List first so an unknown dynamic
+// collection or unknown object element is not decoded into the native
+// []XrayDNSServer model.
+func (r *XrayDNSResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	var serverAttr types.List
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, resourcepath.Root("server"), &serverAttr)...)
+	if resp.Diagnostics.HasError() || serverAttr.IsUnknown() {
+		return
+	}
+	for _, server := range serverAttr.Elements() {
+		if server.IsUnknown() {
+			return
+		}
+	}
+
+	var config, plan XrayDNSModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() || reflect.DeepEqual(plan.Server, config.Server) {
+		return
+	}
+
+	plan.Server = config.Server
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/resource_xray_settings.go
+++ b/provider/resource_xray_settings.go
@@ -321,34 +321,27 @@ func (r *XrayDNSResource) ImportState(ctx context.Context, _ resource.ImportStat
 // ModifyPlan keeps configured DNS server blocks authoritative. Nested
 // Optional+Computed attributes use UseStateForUnknown, which otherwise carries
 // values from the prior occupant of the same list index when servers are
-// reordered. Read the collection as types.List first so an unknown dynamic
-// collection or unknown object element is not decoded into the native
-// []XrayDNSServer model.
+// reordered. Keep the collection as a framework types.List so unknown object
+// elements and partial unknown leaves remain representable while known siblings
+// are still reconciled.
 func (r *XrayDNSResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
 		return
 	}
 
-	var serverAttr types.List
-	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, resourcepath.Root("server"), &serverAttr)...)
-	if resp.Diagnostics.HasError() || serverAttr.IsUnknown() {
-		return
-	}
-	for _, server := range serverAttr.Elements() {
-		if server.IsUnknown() {
-			return
-		}
-	}
-
-	var config, plan XrayDNSModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() || reflect.DeepEqual(plan.Server, config.Server) {
+	var configured types.List
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, resourcepath.Root("server"), &configured)...)
+	if resp.Diagnostics.HasError() || configured.IsUnknown() {
 		return
 	}
 
-	plan.Server = config.Server
-	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	var planned types.List
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, resourcepath.Root("server"), &planned)...)
+	if resp.Diagnostics.HasError() || planned.Equal(configured) {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, resourcepath.Root("server"), configured)...)
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/xray_dns_plan_test.go
+++ b/provider/xray_dns_plan_test.go
@@ -161,3 +161,75 @@ func TestXrayDNSResourceModifyPlanSkipsUnknownServerCollection(t *testing.T) {
 		t.Fatalf("ModifyPlan must defer an unknown server collection: %v", resp.Diagnostics)
 	}
 }
+
+func TestXrayDNSResourceModifyPlanSkipsNullPlanOrState(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &XrayDNSResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	serverListType := objType.AttributeTypes["server"].(tftypes.List)
+	serverObjType := serverListType.ElementType.(tftypes.Object)
+	servers := tftypes.NewValue(serverListType, []tftypes.Value{
+		dnsServerPlanValue(t, serverObjType, "8.8.8.8", nil, nil, nil),
+	})
+	knownRaw := dnsPlanRaw(t, schemaResp, servers)
+	nullRaw := tftypes.NewValue(objType, nil)
+
+	for _, tc := range []struct {
+		name     string
+		planRaw  tftypes.Value
+		stateRaw tftypes.Value
+	}{
+		{name: "null plan", planRaw: nullRaw, stateRaw: knownRaw},
+		{name: "null state", planRaw: knownRaw, stateRaw: nullRaw},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: tc.planRaw}
+			config := tfsdk.Config{Schema: schemaResp.Schema, Raw: knownRaw}
+			state := tfsdk.State{Schema: schemaResp.Schema, Raw: tc.stateRaw}
+			resp := &resource.ModifyPlanResponse{Plan: plan}
+
+			r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("ModifyPlan must skip null plan/state: %v", resp.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestXrayDNSResourceModifyPlanNoOpWhenServersAlreadyMatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &XrayDNSResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	serverListType := objType.AttributeTypes["server"].(tftypes.List)
+	serverObjType := serverListType.ElementType.(tftypes.Object)
+	servers := tftypes.NewValue(serverListType, []tftypes.Value{
+		dnsServerPlanValue(t, serverObjType, "8.8.8.8", nil, nil, nil),
+	})
+	raw := dnsPlanRaw(t, schemaResp, servers)
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: raw}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: raw}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: raw}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected ModifyPlan diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got XrayDNSModel
+	resp.Diagnostics.Append(resp.Plan.Get(ctx, &got)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("failed to decode unchanged plan: %v", resp.Diagnostics)
+	}
+	if len(got.Server) != 1 || got.Server[0].Address.ValueString() != "8.8.8.8" {
+		t.Fatalf("matching server plan changed unexpectedly: %#v", got.Server)
+	}
+}

--- a/provider/xray_dns_plan_test.go
+++ b/provider/xray_dns_plan_test.go
@@ -4,38 +4,44 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-func dnsServerPlanValue(
-	t *testing.T,
-	objType tftypes.Object,
-	address string,
-	port *int64,
-	domains []string,
-	skipFallback *bool,
-) tftypes.Value {
+func dnsServerPlanValue(t *testing.T, objType tftypes.Object, address string) tftypes.Value {
 	t.Helper()
 	vals := make(map[string]tftypes.Value, len(objType.AttributeTypes))
 	for name, attrType := range objType.AttributeTypes {
 		vals[name] = tftypes.NewValue(attrType, nil)
 	}
 	vals["address"] = tftypes.NewValue(tftypes.String, address)
-	if port != nil {
-		vals["port"] = tftypes.NewValue(tftypes.Number, *port)
+	return tftypes.NewValue(objType, vals)
+}
+
+func dnsRichServerPlanValue(t *testing.T, objType tftypes.Object, address string) tftypes.Value {
+	t.Helper()
+	vals := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		vals[name] = tftypes.NewValue(attrType, nil)
 	}
-	if len(domains) > 0 {
-		elements := make([]tftypes.Value, len(domains))
-		for i, domain := range domains {
-			elements[i] = tftypes.NewValue(tftypes.String, domain)
-		}
-		vals["domains"] = tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, elements)
-	}
-	if skipFallback != nil {
-		vals["skip_fallback"] = tftypes.NewValue(tftypes.Bool, *skipFallback)
-	}
+	vals["address"] = tftypes.NewValue(tftypes.String, address)
+	vals["port"] = tftypes.NewValue(tftypes.Number, int64(5353))
+	vals["domains"] = tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+		tftypes.NewValue(tftypes.String, "geosite:cn"),
+	})
+	vals["expect_ips"] = tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+		tftypes.NewValue(tftypes.String, "geoip:cn"),
+	})
+	vals["unexpected_ips"] = tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{
+		tftypes.NewValue(tftypes.String, "geoip:private"),
+	})
+	vals["skip_fallback"] = tftypes.NewValue(tftypes.Bool, true)
+	vals["query_strategy"] = tftypes.NewValue(tftypes.String, "UseIPv4")
+	vals["disable_cache"] = tftypes.NewValue(tftypes.Bool, true)
+	vals["final_query"] = tftypes.NewValue(tftypes.Bool, true)
 	return tftypes.NewValue(objType, vals)
 }
 
@@ -67,13 +73,11 @@ func TestXrayDNSResourceModifyPlanStripsStaleServerFieldsOnReorder(t *testing.T)
 	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
 	serverListType := objType.AttributeTypes["server"].(tftypes.List)
 	serverObjType := serverListType.ElementType.(tftypes.Object)
-	port := int64(5353)
-	skipFallback := true
 	rich := func(address string) tftypes.Value {
-		return dnsServerPlanValue(t, serverObjType, address, &port, []string{"geosite:cn"}, &skipFallback)
+		return dnsRichServerPlanValue(t, serverObjType, address)
 	}
 	sparse := func(address string) tftypes.Value {
-		return dnsServerPlanValue(t, serverObjType, address, nil, nil, nil)
+		return dnsServerPlanValue(t, serverObjType, address)
 	}
 
 	stateServers := tftypes.NewValue(serverListType, []tftypes.Value{rich("8.8.8.8"), sparse("1.1.1.1")})
@@ -100,15 +104,21 @@ func TestXrayDNSResourceModifyPlanStripsStaleServerFieldsOnReorder(t *testing.T)
 	if len(got.Server) != 2 {
 		t.Fatalf("expected two servers, got %d", len(got.Server))
 	}
-	if !got.Server[0].Port.IsNull() || !got.Server[0].Domains.IsNull() || !got.Server[0].SkipFallback.IsNull() {
+	if !got.Server[0].Port.IsNull() || !got.Server[0].Domains.IsNull() ||
+		!got.Server[0].ExpectIPs.IsNull() || !got.Server[0].UnexpectedIPs.IsNull() ||
+		!got.Server[0].SkipFallback.IsNull() || !got.Server[0].QueryStrategy.IsNull() ||
+		!got.Server[0].DisableCache.IsNull() || !got.Server[0].FinalQuery.IsNull() {
 		t.Fatalf("sparse server inherited stale fields: %#v", got.Server[0])
 	}
-	if got.Server[1].Port.ValueInt64() != port || got.Server[1].Domains.IsNull() || !got.Server[1].SkipFallback.ValueBool() {
+	if got.Server[1].Port.ValueInt64() != 5353 || got.Server[1].Domains.IsNull() ||
+		got.Server[1].ExpectIPs.IsNull() || got.Server[1].UnexpectedIPs.IsNull() ||
+		!got.Server[1].SkipFallback.ValueBool() || got.Server[1].QueryStrategy.ValueString() != "UseIPv4" ||
+		!got.Server[1].DisableCache.ValueBool() || !got.Server[1].FinalQuery.ValueBool() {
 		t.Fatalf("rich server lost configured fields: %#v", got.Server[1])
 	}
 }
 
-func TestXrayDNSResourceModifyPlanSkipsUnknownServerElement(t *testing.T) {
+func TestXrayDNSResourceModifyPlanReconcilesKnownSiblingWithUnknownServerElement(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	r := &XrayDNSResource{}
@@ -118,21 +128,40 @@ func TestXrayDNSResourceModifyPlanSkipsUnknownServerElement(t *testing.T) {
 	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
 	serverListType := objType.AttributeTypes["server"].(tftypes.List)
 	serverObjType := serverListType.ElementType.(tftypes.Object)
-	knownServers := tftypes.NewValue(serverListType, []tftypes.Value{
-		dnsServerPlanValue(t, serverObjType, "8.8.8.8", nil, nil, nil),
+	sparse := dnsServerPlanValue(t, serverObjType, "1.1.1.1")
+	rich := dnsRichServerPlanValue(t, serverObjType, "1.1.1.1")
+	unknown := tftypes.NewValue(serverObjType, tftypes.UnknownValue)
+	stateServers := tftypes.NewValue(serverListType, []tftypes.Value{
+		dnsRichServerPlanValue(t, serverObjType, "8.8.8.8"),
+		sparse,
 	})
-	configServers := tftypes.NewValue(serverListType, []tftypes.Value{
-		tftypes.NewValue(serverObjType, tftypes.UnknownValue),
-	})
+	configServers := tftypes.NewValue(serverListType, []tftypes.Value{sparse, unknown})
+	pollutedPlanServers := tftypes.NewValue(serverListType, []tftypes.Value{rich, unknown})
 
-	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, knownServers)}
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, pollutedPlanServers)}
 	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, configServers)}
-	state := tfsdk.State{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, knownServers)}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, stateServers)}
 	resp := &resource.ModifyPlanResponse{Plan: plan}
 
 	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
 	if resp.Diagnostics.HasError() {
-		t.Fatalf("ModifyPlan must defer an unknown server element: %v", resp.Diagnostics)
+		t.Fatalf("ModifyPlan must preserve an unknown server element: %v", resp.Diagnostics)
+	}
+
+	var got types.List
+	resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, path.Root("server"), &got)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("failed to read reconciled server list: %v", resp.Diagnostics)
+	}
+	if len(got.Elements()) != 2 || !got.Elements()[1].IsUnknown() {
+		t.Fatalf("unknown server element was not preserved: %s", got)
+	}
+	known, ok := got.Elements()[0].(types.Object)
+	if !ok {
+		t.Fatalf("known server has unexpected type %T", got.Elements()[0])
+	}
+	if port := known.Attributes()["port"].(types.Int64); !port.IsNull() {
+		t.Fatalf("known sparse sibling retained stale port: %s", port)
 	}
 }
 
@@ -147,7 +176,7 @@ func TestXrayDNSResourceModifyPlanSkipsUnknownServerCollection(t *testing.T) {
 	serverListType := objType.AttributeTypes["server"].(tftypes.List)
 	serverObjType := serverListType.ElementType.(tftypes.Object)
 	knownServers := tftypes.NewValue(serverListType, []tftypes.Value{
-		dnsServerPlanValue(t, serverObjType, "8.8.8.8", nil, nil, nil),
+		dnsServerPlanValue(t, serverObjType, "8.8.8.8"),
 	})
 	unknownServers := tftypes.NewValue(serverListType, tftypes.UnknownValue)
 
@@ -173,7 +202,7 @@ func TestXrayDNSResourceModifyPlanSkipsNullPlanOrState(t *testing.T) {
 	serverListType := objType.AttributeTypes["server"].(tftypes.List)
 	serverObjType := serverListType.ElementType.(tftypes.Object)
 	servers := tftypes.NewValue(serverListType, []tftypes.Value{
-		dnsServerPlanValue(t, serverObjType, "8.8.8.8", nil, nil, nil),
+		dnsServerPlanValue(t, serverObjType, "8.8.8.8"),
 	})
 	knownRaw := dnsPlanRaw(t, schemaResp, servers)
 	nullRaw := tftypes.NewValue(objType, nil)
@@ -211,7 +240,7 @@ func TestXrayDNSResourceModifyPlanNoOpWhenServersAlreadyMatch(t *testing.T) {
 	serverListType := objType.AttributeTypes["server"].(tftypes.List)
 	serverObjType := serverListType.ElementType.(tftypes.Object)
 	servers := tftypes.NewValue(serverListType, []tftypes.Value{
-		dnsServerPlanValue(t, serverObjType, "8.8.8.8", nil, nil, nil),
+		dnsServerPlanValue(t, serverObjType, "8.8.8.8"),
 	})
 	raw := dnsPlanRaw(t, schemaResp, servers)
 	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: raw}

--- a/provider/xray_dns_plan_test.go
+++ b/provider/xray_dns_plan_test.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func dnsServerPlanValue(
+	t *testing.T,
+	objType tftypes.Object,
+	address string,
+	port *int64,
+	domains []string,
+	skipFallback *bool,
+) tftypes.Value {
+	t.Helper()
+	vals := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		vals[name] = tftypes.NewValue(attrType, nil)
+	}
+	vals["address"] = tftypes.NewValue(tftypes.String, address)
+	if port != nil {
+		vals["port"] = tftypes.NewValue(tftypes.Number, *port)
+	}
+	if len(domains) > 0 {
+		elements := make([]tftypes.Value, len(domains))
+		for i, domain := range domains {
+			elements[i] = tftypes.NewValue(tftypes.String, domain)
+		}
+		vals["domains"] = tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, elements)
+	}
+	if skipFallback != nil {
+		vals["skip_fallback"] = tftypes.NewValue(tftypes.Bool, *skipFallback)
+	}
+	return tftypes.NewValue(objType, vals)
+}
+
+func dnsPlanRaw(t *testing.T, schemaResp resource.SchemaResponse, servers tftypes.Value) tftypes.Value {
+	t.Helper()
+	ctx := context.Background()
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	vals := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		switch name {
+		case "id":
+			vals[name] = tftypes.NewValue(tftypes.String, xraySectionDNS.id)
+		case "server":
+			vals[name] = servers
+		default:
+			vals[name] = tftypes.NewValue(attrType, nil)
+		}
+	}
+	return tftypes.NewValue(objType, vals)
+}
+
+func TestXrayDNSResourceModifyPlanStripsStaleServerFieldsOnReorder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &XrayDNSResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	serverListType := objType.AttributeTypes["server"].(tftypes.List)
+	serverObjType := serverListType.ElementType.(tftypes.Object)
+	port := int64(5353)
+	skipFallback := true
+	rich := func(address string) tftypes.Value {
+		return dnsServerPlanValue(t, serverObjType, address, &port, []string{"geosite:cn"}, &skipFallback)
+	}
+	sparse := func(address string) tftypes.Value {
+		return dnsServerPlanValue(t, serverObjType, address, nil, nil, nil)
+	}
+
+	stateServers := tftypes.NewValue(serverListType, []tftypes.Value{rich("8.8.8.8"), sparse("1.1.1.1")})
+	configServers := tftypes.NewValue(serverListType, []tftypes.Value{sparse("1.1.1.1"), rich("8.8.8.8")})
+	pollutedPlanServers := tftypes.NewValue(serverListType, []tftypes.Value{rich("1.1.1.1"), rich("8.8.8.8")})
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, pollutedPlanServers)}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, configServers)}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, stateServers)}
+	resp := &resource.ModifyPlanResponse{
+		Plan: tfsdk.Plan{Schema: schemaResp.Schema, Raw: tftypes.NewValue(objType, nil)},
+	}
+
+	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected ModifyPlan diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got XrayDNSModel
+	resp.Diagnostics.Append(resp.Plan.Get(ctx, &got)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("failed to decode reconciled plan: %v", resp.Diagnostics)
+	}
+	if len(got.Server) != 2 {
+		t.Fatalf("expected two servers, got %d", len(got.Server))
+	}
+	if !got.Server[0].Port.IsNull() || !got.Server[0].Domains.IsNull() || !got.Server[0].SkipFallback.IsNull() {
+		t.Fatalf("sparse server inherited stale fields: %#v", got.Server[0])
+	}
+	if got.Server[1].Port.ValueInt64() != port || got.Server[1].Domains.IsNull() || !got.Server[1].SkipFallback.ValueBool() {
+		t.Fatalf("rich server lost configured fields: %#v", got.Server[1])
+	}
+}
+
+func TestXrayDNSResourceModifyPlanSkipsUnknownServerElement(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &XrayDNSResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	serverListType := objType.AttributeTypes["server"].(tftypes.List)
+	serverObjType := serverListType.ElementType.(tftypes.Object)
+	knownServers := tftypes.NewValue(serverListType, []tftypes.Value{
+		dnsServerPlanValue(t, serverObjType, "8.8.8.8", nil, nil, nil),
+	})
+	configServers := tftypes.NewValue(serverListType, []tftypes.Value{
+		tftypes.NewValue(serverObjType, tftypes.UnknownValue),
+	})
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, knownServers)}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, configServers)}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, knownServers)}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ModifyPlan must defer an unknown server element: %v", resp.Diagnostics)
+	}
+}
+
+func TestXrayDNSResourceModifyPlanSkipsUnknownServerCollection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := &XrayDNSResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	serverListType := objType.AttributeTypes["server"].(tftypes.List)
+	serverObjType := serverListType.ElementType.(tftypes.Object)
+	knownServers := tftypes.NewValue(serverListType, []tftypes.Value{
+		dnsServerPlanValue(t, serverObjType, "8.8.8.8", nil, nil, nil),
+	})
+	unknownServers := tftypes.NewValue(serverListType, tftypes.UnknownValue)
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, knownServers)}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, unknownServers)}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: dnsPlanRaw(t, schemaResp, knownServers)}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	r.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ModifyPlan must defer an unknown server collection: %v", resp.Diagnostics)
+	}
+}


### PR DESCRIPTION
## Summary

- keep configured DNS `server` blocks authoritative during updates instead of inheriting optional fields from the prior occupant of the same list index
- reconcile with framework list values so known siblings are corrected even when another object is unknown
- add plan-level regression coverage and a live 3x-ui acceptance test that validates Terraform state, raw panel JSON, and idempotency

## Problem

`server` is a `ListNestedBlock` whose optional leaves use `UseStateForUnknown`. On reorder, those modifiers copied `port`, `domains`, and `skip_fallback` from the previous server at the same index. The polluted plan was then written to 3x-ui, changing the meaning of the sparse DNS entry.

## Test plan

- [x] focused reorder regression (RED before fix, GREEN after fix)
- [x] mixed known/unknown list: reconcile the known sibling and preserve the unknown object
- [x] unknown whole server collection
- [x] all eight vulnerable server leaves covered (`port`, `domains`, `expect_ips`, `unexpected_ips`, `skip_fallback`, `query_strategy`, `disable_cache`, `final_query`)
- [x] null plan/state lifecycle guard
- [x] already-aligned no-op path
- [x] `TestAccXrayDNSServersReorderNoFieldBleed` against 3x-ui v3.6.0
  - [x] exact Terraform state fields
  - [x] raw panel Xray JSON
  - [x] no-op follow-up plan
- [x] `go test ./provider -short -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [x] local changed production statements covered
- [x] GitHub Actions and Codecov

Fixes #418
