### PR TITLE
fix: reconcile xray policy levels by id

### DIFF
--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -67,6 +68,100 @@ func TestAccXrayBasicsEmpty(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccXrayBasicsPolicyLevelReorderNoFieldBleed(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderConfig() + testAccXrayBasicsPolicyLevelsConfig(),
+				Check:  testAccCheckXrayBasicsPolicyLevelsExact("threexui_xray_basics.test"),
+			},
+			{
+				Config: testAccProviderConfig() + testAccXrayBasicsPolicyLevelsReversedConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXrayBasicsPolicyLevelsExact("threexui_xray_basics.test"),
+					testAccCheckRawXrayBasicsPolicyLevels(),
+				),
+			},
+			{
+				Config:             testAccProviderConfig() + testAccXrayBasicsPolicyLevelsReversedConfig(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccCheckXrayBasicsPolicyLevelsExact(resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		resourceState, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		attributes := resourceState.Primary.Attributes
+		if got := attributes["policy.0.level.#"]; got != "2" {
+			return fmt.Errorf("expected two policy levels, got %q", got)
+		}
+		expected := map[string]string{
+			"policy.0.level.0.id":        "0",
+			"policy.0.level.0.handshake": "17",
+			"policy.0.level.0.conn_idle": "300",
+			"policy.0.level.1.id":        "1",
+			"policy.0.level.1.handshake": "4",
+			"policy.0.level.1.conn_idle": "123",
+		}
+		for name, want := range expected {
+			if got := attributes[name]; got != want {
+				return fmt.Errorf("%s: got %q, want %q", name, got, want)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckRawXrayBasicsPolicyLevels() resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		client, err := testAccClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("client init failed: %w", err)
+		}
+		template, err := client.GetXrayTemplate(context.Background())
+		if err != nil {
+			return fmt.Errorf("read raw xray template: %w", err)
+		}
+		policy, ok := template["policy"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("raw xray template has no policy object")
+		}
+		levels, ok := policy["levels"].(map[string]any)
+		if !ok || len(levels) != 2 {
+			return fmt.Errorf("raw xray policy must contain exactly two levels, got %#v", policy["levels"])
+		}
+		level0, ok := levels["0"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("raw xray policy level 0 is missing")
+		}
+		level1, ok := levels["1"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("raw xray policy level 1 is missing")
+		}
+		if value, exists := level0["handshake"]; !exists || intValue(value) != 17 {
+			return fmt.Errorf("raw level 0 handshake: got %v, want 17", value)
+		}
+		if value, exists := level0["connIdle"]; !exists || intValue(value) != 300 {
+			return fmt.Errorf("raw level 0 connIdle: got %v, want default 300", value)
+		}
+		if value, exists := level1["connIdle"]; !exists || intValue(value) != 123 {
+			return fmt.Errorf("raw level 1 connIdle: got %v, want 123", value)
+		}
+		if value, exists := level1["handshake"]; !exists || intValue(value) != 4 {
+			return fmt.Errorf("raw level 1 handshake: got %v, want default 4", value)
+		}
+		return nil
+	}
 }
 
 func TestAccXrayDNS(t *testing.T) {
@@ -681,6 +776,50 @@ resource "threexui_xray_basics" "test" {
 func testAccXrayBasicsEmptyConfig() string {
 	return `
 resource "threexui_xray_basics" "test" {}
+`
+}
+
+func testAccXrayBasicsPolicyLevelsConfig() string {
+	return `
+resource "threexui_xray_basics" "test" {
+  log {
+    loglevel = "warning"
+  }
+
+  policy {
+    level {
+      id        = 0
+      handshake = 17
+    }
+
+    level {
+      id        = 1
+      conn_idle = 123
+    }
+  }
+}
+`
+}
+
+func testAccXrayBasicsPolicyLevelsReversedConfig() string {
+	return `
+resource "threexui_xray_basics" "test" {
+  log {
+    loglevel = "warning"
+  }
+
+  policy {
+    level {
+      id        = 1
+      conn_idle = 123
+    }
+
+    level {
+      id        = 0
+      handshake = 17
+    }
+  }
+}
 `
 }
 

--- a/provider/acc_xray_test.go
+++ b/provider/acc_xray_test.go
@@ -77,12 +77,12 @@ func TestAccXrayBasicsPolicyLevelReorderNoFieldBleed(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderConfig() + testAccXrayBasicsPolicyLevelsConfig(),
-				Check:  testAccCheckXrayBasicsPolicyLevelsExact("threexui_xray_basics.test"),
+				Check:  testAccCheckXrayBasicsPolicyLevelsNoFieldBleed("threexui_xray_basics.test"),
 			},
 			{
 				Config: testAccProviderConfig() + testAccXrayBasicsPolicyLevelsReversedConfig(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckXrayBasicsPolicyLevelsExact("threexui_xray_basics.test"),
+					testAccCheckXrayBasicsPolicyLevelsNoFieldBleed("threexui_xray_basics.test"),
 					testAccCheckRawXrayBasicsPolicyLevels(),
 				),
 			},
@@ -95,7 +95,29 @@ func TestAccXrayBasicsPolicyLevelReorderNoFieldBleed(t *testing.T) {
 	})
 }
 
-func testAccCheckXrayBasicsPolicyLevelsExact(resourceName string) resource.TestCheckFunc {
+func TestAccXrayBasicsPolicyLevelMixedKnownUnknownIDNoFieldBleed(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{Config: testAccProviderConfig() + testAccXrayBasicsPolicyLevelsConfig()},
+			{
+				Config: testAccProviderConfig() + testAccXrayBasicsPolicyLevelsMixedUnknownConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckXrayBasicsMixedPolicyLevels("threexui_xray_basics.test"),
+					testAccCheckRawXrayBasicsMixedPolicyLevels(),
+				),
+			},
+			{
+				Config:             testAccProviderConfig() + testAccXrayBasicsPolicyLevelsMixedUnknownConfig(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccCheckXrayBasicsPolicyLevelsNoFieldBleed(resourceName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		resourceState, ok := state.RootModule().Resources[resourceName]
 		if !ok {
@@ -105,18 +127,32 @@ func testAccCheckXrayBasicsPolicyLevelsExact(resourceName string) resource.TestC
 		if got := attributes["policy.0.level.#"]; got != "2" {
 			return fmt.Errorf("expected two policy levels, got %q", got)
 		}
-		expected := map[string]string{
-			"policy.0.level.0.id":        "0",
-			"policy.0.level.0.handshake": "17",
-			"policy.0.level.0.conn_idle": "300",
-			"policy.0.level.1.id":        "1",
-			"policy.0.level.1.handshake": "4",
-			"policy.0.level.1.conn_idle": "123",
-		}
-		for name, want := range expected {
-			if got := attributes[name]; got != want {
-				return fmt.Errorf("%s: got %q, want %q", name, got, want)
+		seen := map[string]bool{}
+		for i := 0; i < 2; i++ {
+			prefix := fmt.Sprintf("policy.0.level.%d", i)
+			switch id := attributes[prefix+".id"]; id {
+			case "0":
+				seen[id] = true
+				if got := attributes[prefix+".handshake"]; got != "17" {
+					return fmt.Errorf("policy level 0 handshake: got %q, want 17", got)
+				}
+				if got := attributes[prefix+".conn_idle"]; got == "123" {
+					return fmt.Errorf("policy level 0 inherited conn_idle=123 from level 1")
+				}
+			case "1":
+				seen[id] = true
+				if got := attributes[prefix+".conn_idle"]; got != "123" {
+					return fmt.Errorf("policy level 1 conn_idle: got %q, want 123", got)
+				}
+				if got := attributes[prefix+".handshake"]; got == "17" {
+					return fmt.Errorf("policy level 1 inherited handshake=17 from level 0")
+				}
+			default:
+				return fmt.Errorf("unexpected policy level ID %q at index %d", id, i)
 			}
+		}
+		if !seen["0"] || !seen["1"] {
+			return fmt.Errorf("expected policy level IDs 0 and 1, got %#v", seen)
 		}
 		return nil
 	}
@@ -151,14 +187,97 @@ func testAccCheckRawXrayBasicsPolicyLevels() resource.TestCheckFunc {
 		if value, exists := level0["handshake"]; !exists || intValue(value) != 17 {
 			return fmt.Errorf("raw level 0 handshake: got %v, want 17", value)
 		}
-		if value, exists := level0["connIdle"]; !exists || intValue(value) != 300 {
-			return fmt.Errorf("raw level 0 connIdle: got %v, want default 300", value)
+		if value, exists := level0["connIdle"]; exists && intValue(value) == 123 {
+			return fmt.Errorf("raw level 0 inherited connIdle=123 from level 1")
 		}
 		if value, exists := level1["connIdle"]; !exists || intValue(value) != 123 {
 			return fmt.Errorf("raw level 1 connIdle: got %v, want 123", value)
 		}
-		if value, exists := level1["handshake"]; !exists || intValue(value) != 4 {
-			return fmt.Errorf("raw level 1 handshake: got %v, want default 4", value)
+		if value, exists := level1["handshake"]; exists && intValue(value) == 17 {
+			return fmt.Errorf("raw level 1 inherited handshake=17 from level 0")
+		}
+		return nil
+	}
+}
+
+func testAccCheckXrayBasicsMixedPolicyLevels(resourceName string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		resourceState, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		attributes := resourceState.Primary.Attributes
+		if got := attributes["policy.0.level.#"]; got != "2" {
+			return fmt.Errorf("expected two policy levels, got %q", got)
+		}
+		seen := map[string]bool{}
+		for i := 0; i < 2; i++ {
+			prefix := fmt.Sprintf("policy.0.level.%d", i)
+			switch id := attributes[prefix+".id"]; id {
+			case "1":
+				seen[id] = true
+				if got := attributes[prefix+".conn_idle"]; got != "123" {
+					return fmt.Errorf("policy level 1 conn_idle: got %q, want 123", got)
+				}
+				if got := attributes[prefix+".handshake"]; got == "17" {
+					return fmt.Errorf("policy level 1 inherited handshake=17 from prior level 0")
+				}
+			case "0":
+				seen[id] = true
+				if got := attributes[prefix+".handshake"]; got != "33" {
+					return fmt.Errorf("policy level 0 handshake: got %q, want 33", got)
+				}
+				if got := attributes[prefix+".conn_idle"]; got == "123" {
+					return fmt.Errorf("policy level 0 inherited conn_idle=123 from prior level 1")
+				}
+			default:
+				return fmt.Errorf("unexpected mixed policy level ID %q at index %d", id, i)
+			}
+		}
+		if !seen["1"] || !seen["0"] {
+			return fmt.Errorf("expected mixed policy level IDs 1 and 0, got %#v", seen)
+		}
+		return nil
+	}
+}
+
+func testAccCheckRawXrayBasicsMixedPolicyLevels() resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		client, err := testAccClientFromEnv()
+		if err != nil {
+			return fmt.Errorf("client init failed: %w", err)
+		}
+		template, err := client.GetXrayTemplate(context.Background())
+		if err != nil {
+			return fmt.Errorf("read raw xray template: %w", err)
+		}
+		policy, ok := template["policy"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("raw xray template has no policy object")
+		}
+		levels, ok := policy["levels"].(map[string]any)
+		if !ok || len(levels) != 2 {
+			return fmt.Errorf("raw xray policy must contain exactly two levels, got %#v", policy["levels"])
+		}
+		level1, ok := levels["1"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("raw xray policy level 1 is missing")
+		}
+		level0, ok := levels["0"].(map[string]any)
+		if !ok {
+			return fmt.Errorf("raw xray policy level 0 is missing")
+		}
+		if value, exists := level1["connIdle"]; !exists || intValue(value) != 123 {
+			return fmt.Errorf("raw level 1 connIdle: got %v, want 123", value)
+		}
+		if value, exists := level1["handshake"]; exists && intValue(value) == 17 {
+			return fmt.Errorf("raw level 1 inherited handshake=17 from prior level 0")
+		}
+		if value, exists := level0["handshake"]; !exists || intValue(value) != 33 {
+			return fmt.Errorf("raw level 0 handshake: got %v, want 33", value)
+		}
+		if value, exists := level0["connIdle"]; exists && intValue(value) == 123 {
+			return fmt.Errorf("raw level 0 inherited connIdle=123 from prior level 1")
 		}
 		return nil
 	}
@@ -817,6 +936,32 @@ resource "threexui_xray_basics" "test" {
     level {
       id        = 0
       handshake = 17
+    }
+  }
+}
+`
+}
+
+func testAccXrayBasicsPolicyLevelsMixedUnknownConfig() string {
+	return `
+resource "terraform_data" "new_level" {
+  input = 0
+}
+
+resource "threexui_xray_basics" "test" {
+  log {
+    loglevel = "warning"
+  }
+
+  policy {
+    level {
+      id        = 1
+      conn_idle = 123
+    }
+
+    level {
+      id        = terraform_data.new_level.output
+      handshake = 33
     }
   }
 }

--- a/provider/resource_xray_settings.go
+++ b/provider/resource_xray_settings.go
@@ -219,21 +219,16 @@ func (r *XrayBasicsResource) ModifyPlan(ctx context.Context, req resource.Modify
 
 	var configuredPolicy types.List
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, resourcepath.Root("policy"), &configuredPolicy)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
+	// The path and destination type are fixed by this resource's schema;
+	// structural null and unknown values are handled by canonicalizeBasicsPolicy.
 
 	priorPolicy := types.ListNull(configuredPolicy.ElementType(ctx))
 	if !req.State.Raw.IsNull() {
 		resp.Diagnostics.Append(req.State.GetAttribute(ctx, resourcepath.Root("policy"), &priorPolicy)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
 	}
 
-	canonicalPolicy, safe, diags := canonicalizeBasicsPolicy(ctx, configuredPolicy, priorPolicy)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() || !safe {
+	canonicalPolicy, safe := canonicalizeBasicsPolicy(ctx, configuredPolicy, priorPolicy)
+	if !safe {
 		return
 	}
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, resourcepath.Root("policy"), canonicalPolicy)...)
@@ -244,10 +239,9 @@ func (r *XrayBasicsResource) ModifyPlan(ctx context.Context, req resource.Modify
 // operates on framework values so unknown leaves remain representable and keeps
 // omitted non-level policy siblings from prior state. Structural unknowns,
 // omitted level collections, and unknown IDs defer to the proposed plan.
-func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.List) (types.List, bool, diag.Diagnostics) {
-	var diags diag.Diagnostics
+func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.List) (types.List, bool) {
 	if policy.IsNull() || policy.IsUnknown() {
-		return policy, false, diags
+		return policy, false
 	}
 
 	priorPoliciesByIndex := make(map[int]types.Object)
@@ -281,13 +275,13 @@ func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.Lis
 	for i, element := range policyElements {
 		policyObject, ok := element.(types.Object)
 		if !ok || policyObject.IsNull() || policyObject.IsUnknown() {
-			return policy, false, diags
+			return policy, false
 		}
 
 		policyAttributes := policyObject.Attributes()
 		levels, ok := policyAttributes["level"].(types.List)
 		if !ok || levels.IsNull() || levels.IsUnknown() {
-			return policy, false, diags
+			return policy, false
 		}
 
 		canonicalAttributes := make(map[string]attr.Value, len(policyAttributes))
@@ -310,11 +304,11 @@ func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.Lis
 		for j, levelElement := range levels.Elements() {
 			levelObject, ok := levelElement.(types.Object)
 			if !ok || levelObject.IsNull() || levelObject.IsUnknown() {
-				return policy, false, diags
+				return policy, false
 			}
 			id, ok := levelObject.Attributes()["id"].(types.Int64)
 			if !ok || id.IsNull() || id.IsUnknown() {
-				return policy, false, diags
+				return policy, false
 			}
 
 			levelAttributes := make(map[string]attr.Value, len(levelObject.Attributes()))
@@ -335,14 +329,10 @@ func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.Lis
 				case types.Bool:
 					levelAttributes[name] = types.BoolUnknown()
 				default:
-					return policy, false, diags
+					return policy, false
 				}
 			}
-			canonicalLevel, levelDiags := types.ObjectValue(levelObject.AttributeTypes(ctx), levelAttributes)
-			diags.Append(levelDiags...)
-			if diags.HasError() {
-				return policy, false, diags
-			}
+			canonicalLevel := types.ObjectValueMust(levelObject.AttributeTypes(ctx), levelAttributes)
 			identifiedLevels[j].id = id.ValueInt64()
 			identifiedLevels[j].value = canonicalLevel
 		}
@@ -355,26 +345,13 @@ func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.Lis
 			levelElements[j] = level.value
 		}
 
-		canonicalLevels, levelDiags := types.ListValue(levels.ElementType(ctx), levelElements)
-		diags.Append(levelDiags...)
-		if diags.HasError() {
-			return policy, false, diags
-		}
+		canonicalLevels := types.ListValueMust(levels.ElementType(ctx), levelElements)
 		canonicalAttributes["level"] = canonicalLevels
-		canonicalPolicy, policyDiags := types.ObjectValue(policyObject.AttributeTypes(ctx), canonicalAttributes)
-		diags.Append(policyDiags...)
-		if diags.HasError() {
-			return policy, false, diags
-		}
+		canonicalPolicy := types.ObjectValueMust(policyObject.AttributeTypes(ctx), canonicalAttributes)
 		canonicalPolicies[i] = canonicalPolicy
 	}
 
-	canonical, policyDiags := types.ListValue(policy.ElementType(ctx), canonicalPolicies)
-	diags.Append(policyDiags...)
-	if diags.HasError() {
-		return policy, false, diags
-	}
-	return canonical, true, diags
+	return types.ListValueMust(policy.ElementType(ctx), canonicalPolicies), true
 }
 
 func (r *XrayBasicsResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/provider/resource_xray_settings.go
+++ b/provider/resource_xray_settings.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"sort"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -211,7 +210,7 @@ func (r *XrayBasicsResource) Update(ctx context.Context, req resource.UpdateRequ
 // ModifyPlan reconciles configured policy levels by the numeric ID used as the
 // remote map key instead of by list index. Explicit config remains authoritative;
 // omitted computed leaves come from state for the same ID (or remain unknown for
-// a new ID), and the result is sorted like flattenBasicsPolicyLevels.
+// a new ID), while configured list order is preserved for Terraform plan validity.
 func (r *XrayBasicsResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		return
@@ -234,11 +233,12 @@ func (r *XrayBasicsResource) ModifyPlan(ctx context.Context, req resource.Modify
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, resourcepath.Root("policy"), canonicalPolicy)...)
 }
 
-// canonicalizeBasicsPolicy returns a policy value whose level objects are
-// matched to prior state and sorted by known numeric ID. It intentionally
+// canonicalizeBasicsPolicy returns a policy list whose configured levels are
+// matched to prior state by known numeric ID without changing configured order. It intentionally
 // operates on framework values so unknown leaves remain representable and keeps
 // omitted non-level policy siblings from prior state. Structural unknowns,
-// omitted level collections, and unknown IDs defer to the proposed plan.
+// omitted level collections defer to the proposed plan. Unknown level objects
+// and IDs stay in place while known siblings are still reconciled by ID.
 func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.List) (types.List, bool) {
 	if policy.IsNull() || policy.IsUnknown() {
 		return policy, false
@@ -297,19 +297,21 @@ func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.Lis
 			}
 		}
 
-		identifiedLevels := make([]struct {
-			id    int64
-			value attr.Value
-		}, len(levels.Elements()))
+		levelElements := make([]attr.Value, len(levels.Elements()))
 		for j, levelElement := range levels.Elements() {
 			levelObject, ok := levelElement.(types.Object)
-			if !ok || levelObject.IsNull() || levelObject.IsUnknown() {
+			if !ok {
 				return policy, false
+			}
+			if levelObject.IsNull() || levelObject.IsUnknown() {
+				levelElements[j] = levelElement
+				continue
 			}
 			id, ok := levelObject.Attributes()["id"].(types.Int64)
-			if !ok || id.IsNull() || id.IsUnknown() {
+			if !ok {
 				return policy, false
 			}
+			idKnown := !id.IsNull() && !id.IsUnknown()
 
 			levelAttributes := make(map[string]attr.Value, len(levelObject.Attributes()))
 			for name, value := range levelObject.Attributes() {
@@ -317,10 +319,12 @@ func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.Lis
 				if name == "id" || !value.IsNull() {
 					continue
 				}
-				if priorLevel, ok := priorLevelsByID[id.ValueInt64()]; ok {
-					if priorValue, ok := priorLevel.Attributes()[name]; ok {
-						levelAttributes[name] = priorValue
-						continue
+				if idKnown {
+					if priorLevel, ok := priorLevelsByID[id.ValueInt64()]; ok {
+						if priorValue, ok := priorLevel.Attributes()[name]; ok {
+							levelAttributes[name] = priorValue
+							continue
+						}
 					}
 				}
 				switch value.(type) {
@@ -333,16 +337,7 @@ func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.Lis
 				}
 			}
 			canonicalLevel := types.ObjectValueMust(levelObject.AttributeTypes(ctx), levelAttributes)
-			identifiedLevels[j].id = id.ValueInt64()
-			identifiedLevels[j].value = canonicalLevel
-		}
-
-		sort.SliceStable(identifiedLevels, func(left, right int) bool {
-			return identifiedLevels[left].id < identifiedLevels[right].id
-		})
-		levelElements := make([]attr.Value, len(identifiedLevels))
-		for j, level := range identifiedLevels {
-			levelElements[j] = level.value
+			levelElements[j] = canonicalLevel
 		}
 
 		canonicalLevels := types.ListValueMust(levels.ElementType(ctx), levelElements)

--- a/provider/resource_xray_settings.go
+++ b/provider/resource_xray_settings.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	resourcepath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -112,6 +114,7 @@ func xrayReadSection(
 var (
 	_ resource.Resource                = &XrayBasicsResource{}
 	_ resource.ResourceWithImportState = &XrayBasicsResource{}
+	_ resource.ResourceWithModifyPlan  = &XrayBasicsResource{}
 )
 
 type XrayBasicsResource struct{ client *Client }
@@ -203,6 +206,175 @@ func (r *XrayBasicsResource) Update(ctx context.Context, req resource.UpdateRequ
 	state := flattenXrayBasics(flat)
 	alignBasicsBlocksWithPlan(state, &plan)
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+// ModifyPlan reconciles configured policy levels by the numeric ID used as the
+// remote map key instead of by list index. Explicit config remains authoritative;
+// omitted computed leaves come from state for the same ID (or remain unknown for
+// a new ID), and the result is sorted like flattenBasicsPolicyLevels.
+func (r *XrayBasicsResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var configuredPolicy types.List
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, resourcepath.Root("policy"), &configuredPolicy)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	priorPolicy := types.ListNull(configuredPolicy.ElementType(ctx))
+	if !req.State.Raw.IsNull() {
+		resp.Diagnostics.Append(req.State.GetAttribute(ctx, resourcepath.Root("policy"), &priorPolicy)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	canonicalPolicy, safe, diags := canonicalizeBasicsPolicy(ctx, configuredPolicy, priorPolicy)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() || !safe {
+		return
+	}
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, resourcepath.Root("policy"), canonicalPolicy)...)
+}
+
+// canonicalizeBasicsPolicy returns a policy value whose level objects are
+// matched to prior state and sorted by known numeric ID. It intentionally
+// operates on framework values so unknown leaves remain representable and keeps
+// omitted non-level policy siblings from prior state. Structural unknowns,
+// omitted level collections, and unknown IDs defer to the proposed plan.
+func canonicalizeBasicsPolicy(ctx context.Context, policy, priorPolicy types.List) (types.List, bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if policy.IsNull() || policy.IsUnknown() {
+		return policy, false, diags
+	}
+
+	priorPoliciesByIndex := make(map[int]types.Object)
+	priorLevelsByID := make(map[int64]types.Object)
+	if !priorPolicy.IsNull() && !priorPolicy.IsUnknown() {
+		for i, priorPolicyElement := range priorPolicy.Elements() {
+			priorPolicyObject, ok := priorPolicyElement.(types.Object)
+			if !ok || priorPolicyObject.IsNull() || priorPolicyObject.IsUnknown() {
+				continue
+			}
+			priorPoliciesByIndex[i] = priorPolicyObject
+			priorLevels, ok := priorPolicyObject.Attributes()["level"].(types.List)
+			if !ok || priorLevels.IsNull() || priorLevels.IsUnknown() {
+				continue
+			}
+			for _, priorLevelElement := range priorLevels.Elements() {
+				priorLevel, ok := priorLevelElement.(types.Object)
+				if !ok || priorLevel.IsNull() || priorLevel.IsUnknown() {
+					continue
+				}
+				id, ok := priorLevel.Attributes()["id"].(types.Int64)
+				if ok && !id.IsNull() && !id.IsUnknown() {
+					priorLevelsByID[id.ValueInt64()] = priorLevel
+				}
+			}
+		}
+	}
+
+	policyElements := policy.Elements()
+	canonicalPolicies := make([]attr.Value, len(policyElements))
+	for i, element := range policyElements {
+		policyObject, ok := element.(types.Object)
+		if !ok || policyObject.IsNull() || policyObject.IsUnknown() {
+			return policy, false, diags
+		}
+
+		policyAttributes := policyObject.Attributes()
+		levels, ok := policyAttributes["level"].(types.List)
+		if !ok || levels.IsNull() || levels.IsUnknown() {
+			return policy, false, diags
+		}
+
+		canonicalAttributes := make(map[string]attr.Value, len(policyAttributes))
+		for name, value := range policyAttributes {
+			canonicalAttributes[name] = value
+			if name == "level" || !value.IsNull() {
+				continue
+			}
+			if priorPolicyObject, ok := priorPoliciesByIndex[i]; ok {
+				if priorValue, ok := priorPolicyObject.Attributes()[name]; ok {
+					canonicalAttributes[name] = priorValue
+				}
+			}
+		}
+
+		identifiedLevels := make([]struct {
+			id    int64
+			value attr.Value
+		}, len(levels.Elements()))
+		for j, levelElement := range levels.Elements() {
+			levelObject, ok := levelElement.(types.Object)
+			if !ok || levelObject.IsNull() || levelObject.IsUnknown() {
+				return policy, false, diags
+			}
+			id, ok := levelObject.Attributes()["id"].(types.Int64)
+			if !ok || id.IsNull() || id.IsUnknown() {
+				return policy, false, diags
+			}
+
+			levelAttributes := make(map[string]attr.Value, len(levelObject.Attributes()))
+			for name, value := range levelObject.Attributes() {
+				levelAttributes[name] = value
+				if name == "id" || !value.IsNull() {
+					continue
+				}
+				if priorLevel, ok := priorLevelsByID[id.ValueInt64()]; ok {
+					if priorValue, ok := priorLevel.Attributes()[name]; ok {
+						levelAttributes[name] = priorValue
+						continue
+					}
+				}
+				switch value.(type) {
+				case types.Int64:
+					levelAttributes[name] = types.Int64Unknown()
+				case types.Bool:
+					levelAttributes[name] = types.BoolUnknown()
+				default:
+					return policy, false, diags
+				}
+			}
+			canonicalLevel, levelDiags := types.ObjectValue(levelObject.AttributeTypes(ctx), levelAttributes)
+			diags.Append(levelDiags...)
+			if diags.HasError() {
+				return policy, false, diags
+			}
+			identifiedLevels[j].id = id.ValueInt64()
+			identifiedLevels[j].value = canonicalLevel
+		}
+
+		sort.SliceStable(identifiedLevels, func(left, right int) bool {
+			return identifiedLevels[left].id < identifiedLevels[right].id
+		})
+		levelElements := make([]attr.Value, len(identifiedLevels))
+		for j, level := range identifiedLevels {
+			levelElements[j] = level.value
+		}
+
+		canonicalLevels, levelDiags := types.ListValue(levels.ElementType(ctx), levelElements)
+		diags.Append(levelDiags...)
+		if diags.HasError() {
+			return policy, false, diags
+		}
+		canonicalAttributes["level"] = canonicalLevels
+		canonicalPolicy, policyDiags := types.ObjectValue(policyObject.AttributeTypes(ctx), canonicalAttributes)
+		diags.Append(policyDiags...)
+		if diags.HasError() {
+			return policy, false, diags
+		}
+		canonicalPolicies[i] = canonicalPolicy
+	}
+
+	canonical, policyDiags := types.ListValue(policy.ElementType(ctx), canonicalPolicies)
+	diags.Append(policyDiags...)
+	if diags.HasError() {
+		return policy, false, diags
+	}
+	return canonical, true, diags
 }
 
 func (r *XrayBasicsResource) Delete(ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/provider/xray_basics_schema.go
+++ b/provider/xray_basics_schema.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -951,7 +952,20 @@ func flattenBasicsPolicyLevels(in map[string]any) []any {
 	for k := range in {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	sort.SliceStable(keys, func(i, j int) bool {
+		left, leftErr := strconv.Atoi(keys[i])
+		right, rightErr := strconv.Atoi(keys[j])
+		if leftErr == nil && rightErr == nil {
+			return left < right
+		}
+		if leftErr == nil {
+			return true
+		}
+		if rightErr == nil {
+			return false
+		}
+		return keys[i] < keys[j]
+	})
 
 	out := make([]any, 0, len(in))
 	for _, key := range keys {

--- a/provider/xray_basics_schema.go
+++ b/provider/xray_basics_schema.go
@@ -297,6 +297,8 @@ func alignBasicsBlocksWithPlan(state, plan *XrayBasicsModel) {
 			}
 			if len(planPol.Level) == 0 {
 				statePol.Level = nil
+			} else {
+				statePol.Level = alignBasicsPolicyLevelsByID(statePol.Level, planPol.Level)
 			}
 		}
 	}
@@ -312,6 +314,36 @@ func alignBasicsBlocksWithPlan(state, plan *XrayBasicsModel) {
 	if len(plan.Env) == 0 {
 		state.Env = nil
 	}
+}
+
+func alignBasicsPolicyLevelsByID(state, reference []XrayBasicsPolicyLevel) []XrayBasicsPolicyLevel {
+	if len(state) < 2 || len(reference) == 0 {
+		return state
+	}
+
+	aligned := make([]XrayBasicsPolicyLevel, 0, len(state))
+	used := make([]bool, len(state))
+	for _, referenceLevel := range reference {
+		if referenceLevel.ID.IsNull() || referenceLevel.ID.IsUnknown() {
+			continue
+		}
+		for i, stateLevel := range state {
+			if used[i] || stateLevel.ID.IsNull() || stateLevel.ID.IsUnknown() {
+				continue
+			}
+			if stateLevel.ID.ValueInt64() == referenceLevel.ID.ValueInt64() {
+				aligned = append(aligned, stateLevel)
+				used[i] = true
+				break
+			}
+		}
+	}
+	for i, stateLevel := range state {
+		if !used[i] {
+			aligned = append(aligned, stateLevel)
+		}
+	}
+	return aligned
 }
 
 // ---------------------------------------------------------------------------

--- a/provider/xray_basics_schema.go
+++ b/provider/xray_basics_schema.go
@@ -943,6 +943,23 @@ func flattenBasicsPolicySystem(in map[string]any) map[string]any {
 	return out
 }
 
+// basicsPolicyLevelKeyLess orders numeric remote policy IDs numerically before
+// any malformed non-numeric keys, which remain deterministic lexically.
+func basicsPolicyLevelKeyLess(leftKey, rightKey string) bool {
+	left, leftErr := strconv.Atoi(leftKey)
+	right, rightErr := strconv.Atoi(rightKey)
+	if leftErr == nil && rightErr == nil {
+		return left < right
+	}
+	if leftErr == nil {
+		return true
+	}
+	if rightErr == nil {
+		return false
+	}
+	return leftKey < rightKey
+}
+
 // flattenBasicsPolicyLevels converts Xray policy.levels map to TF level blocks.
 func flattenBasicsPolicyLevels(in map[string]any) []any {
 	if len(in) == 0 {
@@ -953,18 +970,7 @@ func flattenBasicsPolicyLevels(in map[string]any) []any {
 		keys = append(keys, k)
 	}
 	sort.SliceStable(keys, func(i, j int) bool {
-		left, leftErr := strconv.Atoi(keys[i])
-		right, rightErr := strconv.Atoi(keys[j])
-		if leftErr == nil && rightErr == nil {
-			return left < right
-		}
-		if leftErr == nil {
-			return true
-		}
-		if rightErr == nil {
-			return false
-		}
-		return keys[i] < keys[j]
+		return basicsPolicyLevelKeyLess(keys[i], keys[j])
 	})
 
 	out := make([]any, 0, len(in))

--- a/provider/xray_basics_test.go
+++ b/provider/xray_basics_test.go
@@ -201,6 +201,27 @@ func TestAlignBasicsBlocksWithPlanKeepsEnv(t *testing.T) {
 	}
 }
 
+func TestAlignBasicsBlocksWithPlanOrdersPolicyLevelsByID(t *testing.T) {
+	state := &XrayBasicsModel{Policy: []XrayBasicsPolicy{{Level: []XrayBasicsPolicyLevel{
+		{ID: types.Int64Value(0), Handshake: types.Int64Value(17)},
+		{ID: types.Int64Value(1), ConnIdle: types.Int64Value(123)},
+	}}}}
+	plan := &XrayBasicsModel{Policy: []XrayBasicsPolicy{{Level: []XrayBasicsPolicyLevel{
+		{ID: types.Int64Value(1)},
+		{ID: types.Int64Value(0)},
+	}}}}
+
+	alignBasicsBlocksWithPlan(state, plan)
+
+	levels := state.Policy[0].Level
+	if levels[0].ID.ValueInt64() != 1 || levels[1].ID.ValueInt64() != 0 {
+		t.Fatalf("state levels must follow plan ID order, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
+	}
+	if levels[0].ConnIdle.ValueInt64() != 123 || levels[1].Handshake.ValueInt64() != 17 {
+		t.Fatalf("state level values must stay attached to their IDs, got %#v", levels)
+	}
+}
+
 func basicsLevelRaw(t *testing.T, levelType tftypes.Object, id int64, fields map[string]tftypes.Value) tftypes.Value {
 	t.Helper()
 	return basicsLevelRawWithID(t, levelType, tftypes.NewValue(tftypes.Number, id), fields)
@@ -249,7 +270,7 @@ func basicsRaw(t *testing.T, schemaResp resource.SchemaResponse, policyList tfty
 	return tftypes.NewValue(resourceType, values)
 }
 
-func TestXrayBasicsResourceModifyPlanCanonicalizesReorderedConfiguredLevels(t *testing.T) {
+func TestXrayBasicsResourceModifyPlanReconcilesReorderedConfiguredLevels(t *testing.T) {
 	ctx := context.Background()
 	r := &XrayBasicsResource{}
 	modifier, ok := any(r).(resource.ResourceWithModifyPlan)
@@ -314,21 +335,21 @@ func TestXrayBasicsResourceModifyPlanCanonicalizesReorderedConfiguredLevels(t *t
 		t.Fatalf("expected one policy with two levels, got %#v", got.Policy)
 	}
 	levels := got.Policy[0].Level
-	if levels[0].ID.ValueInt64() != 0 || levels[1].ID.ValueInt64() != 1 {
-		t.Fatalf("planned levels must be canonicalized by ID, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
+	if levels[0].ID.ValueInt64() != 1 || levels[1].ID.ValueInt64() != 0 {
+		t.Fatalf("planned levels must preserve config order, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
 	}
-	if levels[0].Handshake.ValueInt64() != 17 || levels[0].ConnIdle.ValueInt64() != 300 {
-		t.Fatalf("level 0 must keep its own configured value and same-ID default, got %#v", levels[0])
+	if levels[0].ConnIdle.ValueInt64() != 123 || levels[0].Handshake.ValueInt64() != 4 {
+		t.Fatalf("level 1 must keep its own configured value and same-ID default, got %#v", levels[0])
 	}
-	if levels[1].ConnIdle.ValueInt64() != 123 || levels[1].Handshake.ValueInt64() != 4 {
-		t.Fatalf("level 1 must keep its own configured value and same-ID default, got %#v", levels[1])
+	if levels[1].Handshake.ValueInt64() != 17 || levels[1].ConnIdle.ValueInt64() != 300 {
+		t.Fatalf("level 0 must keep its own configured value and same-ID default, got %#v", levels[1])
 	}
 	if len(got.Policy[0].System) != 1 || !got.Policy[0].System[0].StatsInboundDownlink.ValueBool() {
 		t.Fatalf("omitted policy system sibling must be preserved from state, got %#v", got.Policy[0].System)
 	}
 }
 
-func TestXrayBasicsResourceModifyPlanCanonicalizesReverseOrderOnCreate(t *testing.T) {
+func TestXrayBasicsResourceModifyPlanPreservesReverseOrderOnCreate(t *testing.T) {
 	ctx := context.Background()
 	r := &XrayBasicsResource{}
 	modifier := any(r).(resource.ResourceWithModifyPlan)
@@ -364,12 +385,68 @@ func TestXrayBasicsResourceModifyPlanCanonicalizesReverseOrderOnCreate(t *testin
 		t.Fatalf("cannot decode modified plan: %v", resp.Diagnostics)
 	}
 	levels := got.Policy[0].Level
-	if levels[0].ID.ValueInt64() != 0 || levels[1].ID.ValueInt64() != 2 {
-		t.Fatalf("create plan levels must be canonicalized by ID, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
+	if levels[0].ID.ValueInt64() != 2 || levels[1].ID.ValueInt64() != 0 {
+		t.Fatalf("create plan levels must preserve config order, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
 	}
-	if !levels[0].ConnIdle.IsUnknown() || !levels[1].Handshake.IsUnknown() ||
-		!levels[0].StatsUserUplink.IsUnknown() || !levels[1].StatsUserDownlink.IsUnknown() {
+	if !levels[0].Handshake.IsUnknown() || !levels[1].ConnIdle.IsUnknown() ||
+		!levels[0].StatsUserDownlink.IsUnknown() || !levels[1].StatsUserUplink.IsUnknown() {
 		t.Fatalf("omitted computed level fields must remain unknown, got %#v", levels)
+	}
+}
+
+func TestXrayBasicsResourceModifyPlanReconcilesKnownSiblingWithUnknownLevelID(t *testing.T) {
+	ctx := context.Background()
+	r := &XrayBasicsResource{}
+	modifier := any(r).(resource.ResourceWithModifyPlan)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	resourceType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	policyListType := resourceType.AttributeTypes["policy"].(tftypes.List)
+	policyType := policyListType.ElementType.(tftypes.Object)
+	levelListType := policyType.AttributeTypes["level"].(tftypes.List)
+	levelType := levelListType.ElementType.(tftypes.Object)
+	intValue := func(value int64) tftypes.Value {
+		return tftypes.NewValue(tftypes.Number, value)
+	}
+	unknownID := tftypes.NewValue(tftypes.Number, tftypes.UnknownValue)
+
+	configuredLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRawWithID(t, levelType, unknownID, map[string]tftypes.Value{"handshake": intValue(17)}),
+		basicsLevelRaw(t, levelType, 1, map[string]tftypes.Value{"conn_idle": intValue(123)}),
+	})
+	pollutedLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRawWithID(t, levelType, unknownID, map[string]tftypes.Value{"handshake": intValue(17)}),
+		basicsLevelRaw(t, levelType, 1, map[string]tftypes.Value{"handshake": intValue(17), "conn_idle": intValue(123)}),
+	})
+	priorLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRaw(t, levelType, 0, map[string]tftypes.Value{"handshake": intValue(17), "conn_idle": intValue(300)}),
+		basicsLevelRaw(t, levelType, 1, map[string]tftypes.Value{"handshake": intValue(4), "conn_idle": intValue(123)}),
+	})
+	policyList := func(levels tftypes.Value) tftypes.Value {
+		return tftypes.NewValue(policyListType, []tftypes.Value{basicsPolicyRaw(t, policyType, levels)})
+	}
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList(pollutedLevels))}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList(configuredLevels))}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList(priorLevels))}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected ModifyPlan diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got XrayBasicsModel
+	resp.Diagnostics.Append(resp.Plan.Get(ctx, &got)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("cannot decode modified plan: %v", resp.Diagnostics)
+	}
+	levels := got.Policy[0].Level
+	if !levels[0].ID.IsUnknown() {
+		t.Fatalf("unknown level ID must remain unknown, got %#v", levels[0].ID)
+	}
+	if levels[1].ID.ValueInt64() != 1 || levels[1].Handshake.ValueInt64() != 4 {
+		t.Fatalf("known id=1 sibling must keep its same-ID handshake=4, got %#v", levels[1])
 	}
 }
 
@@ -404,16 +481,6 @@ func TestXrayBasicsResourceModifyPlanPreservesUnknownPolicyShapes(t *testing.T) 
 		"level collection": tftypes.NewValue(policyListType, []tftypes.Value{
 			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, tftypes.UnknownValue)),
 		}),
-		"level element": tftypes.NewValue(policyListType, []tftypes.Value{
-			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, []tftypes.Value{
-				tftypes.NewValue(levelType, tftypes.UnknownValue),
-			})),
-		}),
-		"level id": tftypes.NewValue(policyListType, []tftypes.Value{
-			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, []tftypes.Value{
-				basicsLevelRawWithID(t, levelType, tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil),
-			})),
-		}),
 	}
 
 	for name, configuredPolicy := range tests {
@@ -429,6 +496,50 @@ func TestXrayBasicsResourceModifyPlanPreservesUnknownPolicyShapes(t *testing.T) 
 			}
 		})
 	}
+
+	t.Run("level element stays unresolved", func(t *testing.T) {
+		configuredPolicy := tftypes.NewValue(policyListType, []tftypes.Value{
+			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, []tftypes.Value{
+				tftypes.NewValue(levelType, tftypes.UnknownValue),
+			})),
+		})
+		config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, configuredPolicy)}
+		resp := &resource.ModifyPlanResponse{Plan: plan}
+		modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unknown level element must not produce diagnostics: %v", resp.Diagnostics)
+		}
+		var policyValue types.List
+		resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, resourcepath.Root("policy"), &policyValue)...)
+		policyObject := policyValue.Elements()[0].(types.Object)
+		levels := policyObject.Attributes()["level"].(types.List)
+		if !levels.Elements()[0].(types.Object).IsUnknown() {
+			t.Fatalf("unknown level element must remain unresolved, got %v", levels.Elements()[0])
+		}
+	})
+
+	t.Run("level id stays unresolved", func(t *testing.T) {
+		configuredPolicy := tftypes.NewValue(policyListType, []tftypes.Value{
+			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, []tftypes.Value{
+				basicsLevelRawWithID(t, levelType, tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil),
+			})),
+		})
+		config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, configuredPolicy)}
+		resp := &resource.ModifyPlanResponse{Plan: plan}
+		modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+		if resp.Diagnostics.HasError() {
+			t.Fatalf("unknown level ID must not produce diagnostics: %v", resp.Diagnostics)
+		}
+		var policyValue types.List
+		resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, resourcepath.Root("policy"), &policyValue)...)
+		policyObject := policyValue.Elements()[0].(types.Object)
+		levels := policyObject.Attributes()["level"].(types.List)
+		level := levels.Elements()[0].(types.Object)
+		if !level.Attributes()["id"].(types.Int64).IsUnknown() ||
+			!level.Attributes()["handshake"].(types.Int64).IsUnknown() {
+			t.Fatalf("unknown-ID level must remain unresolved without positional state, got %v", level)
+		}
+	})
 
 	priorTests := map[string]tftypes.Value{
 		"unknown policy object": tftypes.NewValue(policyListType, []tftypes.Value{
@@ -525,11 +636,11 @@ func TestXrayBasicsResourceModifyPlanSortsWithUnknownNonIDLeaf(t *testing.T) {
 		t.Fatalf("cannot decode modified plan: %v", resp.Diagnostics)
 	}
 	levels := got.Policy[0].Level
-	if levels[0].ID.ValueInt64() != 0 || levels[1].ID.ValueInt64() != 1 {
-		t.Fatalf("levels with known IDs must still be sorted, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
+	if levels[0].ID.ValueInt64() != 1 || levels[1].ID.ValueInt64() != 0 {
+		t.Fatalf("levels with known IDs must preserve config order, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
 	}
-	if !levels[1].Handshake.IsUnknown() {
-		t.Fatalf("configured unknown handshake must replace stale planned value, got %v", levels[1].Handshake)
+	if !levels[0].Handshake.IsUnknown() {
+		t.Fatalf("configured unknown handshake must replace stale planned value, got %v", levels[0].Handshake)
 	}
 }
 

--- a/provider/xray_basics_test.go
+++ b/provider/xray_basics_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	resourcepath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -433,6 +434,9 @@ func TestXrayBasicsResourceModifyPlanPreservesUnknownPolicyShapes(t *testing.T) 
 		"unknown policy object": tftypes.NewValue(policyListType, []tftypes.Value{
 			tftypes.NewValue(policyType, tftypes.UnknownValue),
 		}),
+		"unknown level collection": tftypes.NewValue(policyListType, []tftypes.Value{
+			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, tftypes.UnknownValue)),
+		}),
 		"unknown level element": tftypes.NewValue(policyListType, []tftypes.Value{
 			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, []tftypes.Value{
 				tftypes.NewValue(levelType, tftypes.UnknownValue),
@@ -449,6 +453,25 @@ func TestXrayBasicsResourceModifyPlanPreservesUnknownPolicyShapes(t *testing.T) 
 				t.Fatalf("%s must be ignored without diagnostics: %v", name, resp.Diagnostics)
 			}
 		})
+	}
+}
+
+func TestCanonicalizeBasicsPolicyDefersUnsupportedNullLeafType(t *testing.T) {
+	ctx := context.Background()
+	levelTypes := map[string]attr.Type{"id": types.Int64Type, "future": types.StringType}
+	level := types.ObjectValueMust(levelTypes, map[string]attr.Value{
+		"id": types.Int64Value(1), "future": types.StringNull(),
+	})
+	levelType := types.ObjectType{AttrTypes: levelTypes}
+	levels := types.ListValueMust(levelType, []attr.Value{level})
+	policyTypes := map[string]attr.Type{"level": types.ListType{ElemType: levelType}}
+	policy := types.ObjectValueMust(policyTypes, map[string]attr.Value{"level": levels})
+	policyType := types.ObjectType{AttrTypes: policyTypes}
+	policies := types.ListValueMust(policyType, []attr.Value{policy})
+
+	got, safe := canonicalizeBasicsPolicy(ctx, policies, types.ListNull(policyType))
+	if safe || !got.Equal(policies) {
+		t.Fatalf("unsupported future null leaf must defer to proposed plan, safe=%t got=%v", safe, got)
 	}
 }
 
@@ -595,5 +618,27 @@ func TestFlattenBasicsPolicyLevelsSortsNumericBeforeNonnumericKeys(t *testing.T)
 	want := []int{1, 10, 11, 22}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("numeric keys must sort before lexical keys, got %v, want %v", got, want)
+	}
+}
+
+func TestBasicsPolicyLevelKeyLess(t *testing.T) {
+	tests := []struct {
+		name        string
+		left, right string
+		want        bool
+	}{
+		{name: "numeric ascending", left: "1", right: "2", want: true},
+		{name: "numeric descending", left: "2", right: "1", want: false},
+		{name: "numeric before lexical", left: "1", right: "alpha", want: true},
+		{name: "lexical after numeric", left: "alpha", right: "1", want: false},
+		{name: "lexical ascending", left: "alpha", right: "beta", want: true},
+		{name: "lexical descending", left: "beta", right: "alpha", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := basicsPolicyLevelKeyLess(test.left, test.right); got != test.want {
+				t.Fatalf("basicsPolicyLevelKeyLess(%q, %q) = %t, want %t", test.left, test.right, got, test.want)
+			}
+		})
 	}
 }

--- a/provider/xray_basics_test.go
+++ b/provider/xray_basics_test.go
@@ -428,6 +428,28 @@ func TestXrayBasicsResourceModifyPlanPreservesUnknownPolicyShapes(t *testing.T) 
 			}
 		})
 	}
+
+	priorTests := map[string]tftypes.Value{
+		"unknown policy object": tftypes.NewValue(policyListType, []tftypes.Value{
+			tftypes.NewValue(policyType, tftypes.UnknownValue),
+		}),
+		"unknown level element": tftypes.NewValue(policyListType, []tftypes.Value{
+			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, []tftypes.Value{
+				tftypes.NewValue(levelType, tftypes.UnknownValue),
+			})),
+		}),
+	}
+	for name, priorPolicy := range priorTests {
+		t.Run("prior "+name, func(t *testing.T) {
+			config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, knownPolicyList)}
+			priorState := tfsdk.State{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, priorPolicy)}
+			resp := &resource.ModifyPlanResponse{Plan: plan}
+			modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: priorState}, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("%s must be ignored without diagnostics: %v", name, resp.Diagnostics)
+			}
+		})
+	}
 }
 
 func TestXrayBasicsResourceModifyPlanSortsWithUnknownNonIDLeaf(t *testing.T) {
@@ -517,6 +539,26 @@ func TestXrayBasicsResourceModifyPlanPreservesOmittedPolicy(t *testing.T) {
 	}
 }
 
+func TestXrayBasicsResourceModifyPlanPreservesNullDestroyPlan(t *testing.T) {
+	ctx := context.Background()
+	r := &XrayBasicsResource{}
+	modifier := any(r).(resource.ResourceWithModifyPlan)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	resourceType := schemaResp.Schema.Type().TerraformType(ctx)
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: tftypes.NewValue(resourceType, nil)}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("null destroy plan must not produce diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.Plan.Raw.IsNull() {
+		t.Fatalf("null destroy plan must remain null, got %s", resp.Plan.Raw)
+	}
+}
+
 func TestFlattenBasicsPolicyLevelsSortsIDsNumerically(t *testing.T) {
 	levels := flattenBasicsPolicyLevels(map[string]any{
 		"10": map[string]any{"connIdle": 10},
@@ -533,5 +575,25 @@ func TestFlattenBasicsPolicyLevelsSortsIDsNumerically(t *testing.T) {
 	want := []int{1, 2, 10}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("flattened level IDs must use numeric order, got %v, want %v", got, want)
+	}
+}
+
+func TestFlattenBasicsPolicyLevelsSortsNumericBeforeNonnumericKeys(t *testing.T) {
+	levels := flattenBasicsPolicyLevels(map[string]any{
+		"10":    map[string]any{"connIdle": 10},
+		"two":   map[string]any{"connIdle": 22},
+		"1":     map[string]any{"connIdle": 1},
+		"alpha": map[string]any{"connIdle": 11},
+	})
+	if len(levels) != 4 {
+		t.Fatalf("expected four flattened levels, got %d", len(levels))
+	}
+	got := make([]int, len(levels))
+	for i, level := range levels {
+		got[i] = level.(map[string]any)["conn_idle"].(int)
+	}
+	want := []int{1, 10, 11, 22}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("numeric keys must sort before lexical keys, got %v, want %v", got, want)
 	}
 }

--- a/provider/xray_basics_test.go
+++ b/provider/xray_basics_test.go
@@ -1,10 +1,15 @@
 package provider
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	resourcepath "github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 // TestXrayBasicsEnvRoundTrip exercises the env block (3x-ui v3.5.0+, xray-core
@@ -192,5 +197,341 @@ func TestAlignBasicsBlocksWithPlanKeepsEnv(t *testing.T) {
 
 	if len(state.Env) != 1 {
 		t.Fatalf("expected state.Env to be preserved when plan has env, got %v", state.Env)
+	}
+}
+
+func basicsLevelRaw(t *testing.T, levelType tftypes.Object, id int64, fields map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+	return basicsLevelRawWithID(t, levelType, tftypes.NewValue(tftypes.Number, id), fields)
+}
+
+func basicsLevelRawWithID(t *testing.T, levelType tftypes.Object, id tftypes.Value, fields map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+	values := make(map[string]tftypes.Value, len(levelType.AttributeTypes))
+	for name, attrType := range levelType.AttributeTypes {
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	values["id"] = id
+	for name, value := range fields {
+		values[name] = value
+	}
+	return tftypes.NewValue(levelType, values)
+}
+
+func basicsPolicyRaw(t *testing.T, policyType tftypes.Object, levelList tftypes.Value) tftypes.Value {
+	t.Helper()
+	return basicsPolicyRawWithFields(t, policyType, map[string]tftypes.Value{"level": levelList})
+}
+
+func basicsPolicyRawWithFields(t *testing.T, policyType tftypes.Object, fields map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+	values := make(map[string]tftypes.Value, len(policyType.AttributeTypes))
+	for name, attrType := range policyType.AttributeTypes {
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	for name, value := range fields {
+		values[name] = value
+	}
+	return tftypes.NewValue(policyType, values)
+}
+
+func basicsRaw(t *testing.T, schemaResp resource.SchemaResponse, policyList tftypes.Value) tftypes.Value {
+	t.Helper()
+	ctx := context.Background()
+	resourceType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	values := make(map[string]tftypes.Value, len(resourceType.AttributeTypes))
+	for name, attrType := range resourceType.AttributeTypes {
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	values["id"] = tftypes.NewValue(tftypes.String, "xray_basics")
+	values["policy"] = policyList
+	return tftypes.NewValue(resourceType, values)
+}
+
+func TestXrayBasicsResourceModifyPlanCanonicalizesReorderedConfiguredLevels(t *testing.T) {
+	ctx := context.Background()
+	r := &XrayBasicsResource{}
+	modifier, ok := any(r).(resource.ResourceWithModifyPlan)
+	if !ok {
+		t.Fatal("XrayBasicsResource must implement ResourceWithModifyPlan")
+	}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	resourceType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	policyListType := resourceType.AttributeTypes["policy"].(tftypes.List)
+	policyType := policyListType.ElementType.(tftypes.Object)
+	levelListType := policyType.AttributeTypes["level"].(tftypes.List)
+	levelType := levelListType.ElementType.(tftypes.Object)
+	systemListType := policyType.AttributeTypes["system"].(tftypes.List)
+	systemType := systemListType.ElementType.(tftypes.Object)
+
+	intValue := func(value int64) tftypes.Value {
+		return tftypes.NewValue(tftypes.Number, value)
+	}
+	configuredLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRaw(t, levelType, 1, map[string]tftypes.Value{"conn_idle": intValue(123)}),
+		basicsLevelRaw(t, levelType, 0, map[string]tftypes.Value{"handshake": intValue(17)}),
+	})
+	pollutedLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRaw(t, levelType, 1, map[string]tftypes.Value{"handshake": intValue(17), "conn_idle": intValue(123)}),
+		basicsLevelRaw(t, levelType, 0, map[string]tftypes.Value{"handshake": intValue(17), "conn_idle": intValue(123)}),
+	})
+	priorLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRaw(t, levelType, 0, map[string]tftypes.Value{"handshake": intValue(17), "conn_idle": intValue(300)}),
+		basicsLevelRaw(t, levelType, 1, map[string]tftypes.Value{"handshake": intValue(4), "conn_idle": intValue(123)}),
+	})
+	systemValues := make(map[string]tftypes.Value, len(systemType.AttributeTypes))
+	for name, attrType := range systemType.AttributeTypes {
+		systemValues[name] = tftypes.NewValue(attrType, nil)
+	}
+	systemValues["stats_inbound_downlink"] = tftypes.NewValue(tftypes.Bool, true)
+	priorSystem := tftypes.NewValue(systemListType, []tftypes.Value{tftypes.NewValue(systemType, systemValues)})
+	policyList := func(levels tftypes.Value) tftypes.Value {
+		return tftypes.NewValue(policyListType, []tftypes.Value{basicsPolicyRaw(t, policyType, levels)})
+	}
+	priorPolicyList := tftypes.NewValue(policyListType, []tftypes.Value{
+		basicsPolicyRawWithFields(t, policyType, map[string]tftypes.Value{"level": priorLevels, "system": priorSystem}),
+	})
+
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList(pollutedLevels))}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList(configuredLevels))}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, priorPolicyList)}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected ModifyPlan diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got XrayBasicsModel
+	resp.Diagnostics.Append(resp.Plan.Get(ctx, &got)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("cannot decode modified plan: %v", resp.Diagnostics)
+	}
+	if len(got.Policy) != 1 || len(got.Policy[0].Level) != 2 {
+		t.Fatalf("expected one policy with two levels, got %#v", got.Policy)
+	}
+	levels := got.Policy[0].Level
+	if levels[0].ID.ValueInt64() != 0 || levels[1].ID.ValueInt64() != 1 {
+		t.Fatalf("planned levels must be canonicalized by ID, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
+	}
+	if levels[0].Handshake.ValueInt64() != 17 || levels[0].ConnIdle.ValueInt64() != 300 {
+		t.Fatalf("level 0 must keep its own configured value and same-ID default, got %#v", levels[0])
+	}
+	if levels[1].ConnIdle.ValueInt64() != 123 || levels[1].Handshake.ValueInt64() != 4 {
+		t.Fatalf("level 1 must keep its own configured value and same-ID default, got %#v", levels[1])
+	}
+	if len(got.Policy[0].System) != 1 || !got.Policy[0].System[0].StatsInboundDownlink.ValueBool() {
+		t.Fatalf("omitted policy system sibling must be preserved from state, got %#v", got.Policy[0].System)
+	}
+}
+
+func TestXrayBasicsResourceModifyPlanCanonicalizesReverseOrderOnCreate(t *testing.T) {
+	ctx := context.Background()
+	r := &XrayBasicsResource{}
+	modifier := any(r).(resource.ResourceWithModifyPlan)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	resourceType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	policyListType := resourceType.AttributeTypes["policy"].(tftypes.List)
+	policyType := policyListType.ElementType.(tftypes.Object)
+	levelListType := policyType.AttributeTypes["level"].(tftypes.List)
+	levelType := levelListType.ElementType.(tftypes.Object)
+
+	configuredLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRaw(t, levelType, 2, map[string]tftypes.Value{"conn_idle": tftypes.NewValue(tftypes.Number, int64(120))}),
+		basicsLevelRaw(t, levelType, 0, map[string]tftypes.Value{"handshake": tftypes.NewValue(tftypes.Number, int64(4))}),
+	})
+	policyList := tftypes.NewValue(policyListType, []tftypes.Value{
+		basicsPolicyRaw(t, policyType, configuredLevels),
+	})
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList)}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList)}
+	nullState := tfsdk.State{Schema: schemaResp.Schema, Raw: tftypes.NewValue(resourceType, nil)}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: nullState}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected ModifyPlan diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got XrayBasicsModel
+	resp.Diagnostics.Append(resp.Plan.Get(ctx, &got)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("cannot decode modified plan: %v", resp.Diagnostics)
+	}
+	levels := got.Policy[0].Level
+	if levels[0].ID.ValueInt64() != 0 || levels[1].ID.ValueInt64() != 2 {
+		t.Fatalf("create plan levels must be canonicalized by ID, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
+	}
+	if !levels[0].ConnIdle.IsUnknown() || !levels[1].Handshake.IsUnknown() ||
+		!levels[0].StatsUserUplink.IsUnknown() || !levels[1].StatsUserDownlink.IsUnknown() {
+		t.Fatalf("omitted computed level fields must remain unknown, got %#v", levels)
+	}
+}
+
+func TestXrayBasicsResourceModifyPlanPreservesUnknownPolicyShapes(t *testing.T) {
+	ctx := context.Background()
+	r := &XrayBasicsResource{}
+	modifier, ok := any(r).(resource.ResourceWithModifyPlan)
+	if !ok {
+		t.Fatal("XrayBasicsResource must implement ResourceWithModifyPlan")
+	}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	resourceType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	policyListType := resourceType.AttributeTypes["policy"].(tftypes.List)
+	policyType := policyListType.ElementType.(tftypes.Object)
+	levelListType := policyType.AttributeTypes["level"].(tftypes.List)
+	levelType := levelListType.ElementType.(tftypes.Object)
+
+	knownLevel := basicsLevelRaw(t, levelType, 0, nil)
+	knownLevels := tftypes.NewValue(levelListType, []tftypes.Value{knownLevel})
+	knownPolicy := basicsPolicyRaw(t, policyType, knownLevels)
+	knownPolicyList := tftypes.NewValue(policyListType, []tftypes.Value{knownPolicy})
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, knownPolicyList)}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, knownPolicyList)}
+
+	tests := map[string]tftypes.Value{
+		"policy collection": tftypes.NewValue(policyListType, tftypes.UnknownValue),
+		"policy object": tftypes.NewValue(policyListType, []tftypes.Value{
+			tftypes.NewValue(policyType, tftypes.UnknownValue),
+		}),
+		"level collection": tftypes.NewValue(policyListType, []tftypes.Value{
+			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, tftypes.UnknownValue)),
+		}),
+		"level element": tftypes.NewValue(policyListType, []tftypes.Value{
+			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, []tftypes.Value{
+				tftypes.NewValue(levelType, tftypes.UnknownValue),
+			})),
+		}),
+		"level id": tftypes.NewValue(policyListType, []tftypes.Value{
+			basicsPolicyRaw(t, policyType, tftypes.NewValue(levelListType, []tftypes.Value{
+				basicsLevelRawWithID(t, levelType, tftypes.NewValue(tftypes.Number, tftypes.UnknownValue), nil),
+			})),
+		}),
+	}
+
+	for name, configuredPolicy := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, configuredPolicy)}
+			resp := &resource.ModifyPlanResponse{Plan: plan}
+			modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unknown %s must not produce diagnostics: %v", name, resp.Diagnostics)
+			}
+			if !resp.Plan.Raw.Equal(plan.Raw) {
+				t.Fatalf("unknown %s must preserve the proposed plan\n got: %s\nwant: %s", name, resp.Plan.Raw, plan.Raw)
+			}
+		})
+	}
+}
+
+func TestXrayBasicsResourceModifyPlanSortsWithUnknownNonIDLeaf(t *testing.T) {
+	ctx := context.Background()
+	r := &XrayBasicsResource{}
+	modifier, ok := any(r).(resource.ResourceWithModifyPlan)
+	if !ok {
+		t.Fatal("XrayBasicsResource must implement ResourceWithModifyPlan")
+	}
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	resourceType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	policyListType := resourceType.AttributeTypes["policy"].(tftypes.List)
+	policyType := policyListType.ElementType.(tftypes.Object)
+	levelListType := policyType.AttributeTypes["level"].(tftypes.List)
+	levelType := levelListType.ElementType.(tftypes.Object)
+
+	configuredLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRaw(t, levelType, 1, map[string]tftypes.Value{
+			"handshake": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+		}),
+		basicsLevelRaw(t, levelType, 0, map[string]tftypes.Value{
+			"handshake": tftypes.NewValue(tftypes.Number, int64(4)),
+		}),
+	})
+	pollutedLevels := tftypes.NewValue(levelListType, []tftypes.Value{
+		basicsLevelRaw(t, levelType, 1, map[string]tftypes.Value{
+			"handshake": tftypes.NewValue(tftypes.Number, int64(99)),
+		}),
+		basicsLevelRaw(t, levelType, 0, map[string]tftypes.Value{
+			"handshake": tftypes.NewValue(tftypes.Number, int64(4)),
+		}),
+	})
+	policyList := func(levels tftypes.Value) tftypes.Value {
+		return tftypes.NewValue(policyListType, []tftypes.Value{basicsPolicyRaw(t, policyType, levels)})
+	}
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList(pollutedLevels))}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList(configuredLevels))}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, policyList(pollutedLevels))}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unknown non-ID leaf must remain representable: %v", resp.Diagnostics)
+	}
+	var got XrayBasicsModel
+	resp.Diagnostics.Append(resp.Plan.Get(ctx, &got)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("cannot decode modified plan: %v", resp.Diagnostics)
+	}
+	levels := got.Policy[0].Level
+	if levels[0].ID.ValueInt64() != 0 || levels[1].ID.ValueInt64() != 1 {
+		t.Fatalf("levels with known IDs must still be sorted, got [%d, %d]", levels[0].ID.ValueInt64(), levels[1].ID.ValueInt64())
+	}
+	if !levels[1].Handshake.IsUnknown() {
+		t.Fatalf("configured unknown handshake must replace stale planned value, got %v", levels[1].Handshake)
+	}
+}
+
+func TestXrayBasicsResourceModifyPlanPreservesOmittedPolicy(t *testing.T) {
+	ctx := context.Background()
+	r := &XrayBasicsResource{}
+	modifier := any(r).(resource.ResourceWithModifyPlan)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	resourceType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	policyListType := resourceType.AttributeTypes["policy"].(tftypes.List)
+	nullPolicy := tftypes.NewValue(policyListType, nil)
+	plan := tfsdk.Plan{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, nullPolicy)}
+	config := tfsdk.Config{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, nullPolicy)}
+	state := tfsdk.State{Schema: schemaResp.Schema, Raw: basicsRaw(t, schemaResp, nullPolicy)}
+	resp := &resource.ModifyPlanResponse{Plan: plan}
+
+	modifier.ModifyPlan(ctx, resource.ModifyPlanRequest{Plan: plan, Config: config, State: state}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("omitted policy must not produce diagnostics: %v", resp.Diagnostics)
+	}
+	var gotPolicy types.List
+	resp.Diagnostics.Append(resp.Plan.GetAttribute(ctx, resourcepath.Root("policy"), &gotPolicy)...)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("cannot read modified policy plan: %v", resp.Diagnostics)
+	}
+	if !gotPolicy.IsNull() {
+		t.Fatalf("omitted policy must remain null, got %v", gotPolicy)
+	}
+}
+
+func TestFlattenBasicsPolicyLevelsSortsIDsNumerically(t *testing.T) {
+	levels := flattenBasicsPolicyLevels(map[string]any{
+		"10": map[string]any{"connIdle": 10},
+		"2":  map[string]any{"connIdle": 2},
+		"1":  map[string]any{"connIdle": 1},
+	})
+	if len(levels) != 3 {
+		t.Fatalf("expected three flattened levels, got %d", len(levels))
+	}
+	got := make([]int, len(levels))
+	for i, level := range levels {
+		got[i] = level.(map[string]any)["id"].(int)
+	}
+	want := []int{1, 2, 10}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("flattened level IDs must use numeric order, got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- reconcile configured `policy.level` blocks by numeric `id` instead of list index
- preserve configured list order in Terraform plans while matching omitted computed leaves to prior state by the same known ID
- reconcile known siblings even when another level object or ID is unknown, without retaining positional prior values on the unresolved element
- align remote state to plan/prior-state ID order after create, update, and refresh; keep numeric sorting only for deterministic remote flatten/import
- verify Terraform state, persisted Xray template JSON, mixed known/unknown IDs, and no-op follow-up plans

## Problem

`policy.level` is a repeatable list whose optional computed descendants use `UseStateForUnknown`, while the panel stores levels in a map keyed by numeric ID. Reordering levels can therefore copy fields from the old list occupant into another ID. An all-or-nothing return for one unknown ID left known siblings polluted, while sorting configured `ListNestedBlock` values in `ModifyPlan` produced an invalid Terraform plan.

## Verification

- [x] focused RED on the buggy head: known `id = 1` retained foreign positional `handshake = 17` beside an unknown ID
- [x] focused GREEN: known siblings reconcile independently by stable ID; unknown objects/IDs stay unresolved and in place
- [x] real Terraform RED on 3x-ui v3.2.6: provider-produced invalid plan when configured levels were sorted
- [x] real Terraform GREEN: `ModifyPlan` preserves config order and post-read state aligns by ID
- [x] `TestAccXrayBasicsPolicyLevelReorderNoFieldBleed` against 3x-ui v3.2.6 and v3.6.0
  - [x] Terraform state assertions by ID
  - [x] persisted panel Xray template assertions by ID
  - [x] version-neutral default handling
  - [x] no-op follow-up plan
- [x] `TestAccXrayBasicsPolicyLevelMixedKnownUnknownIDNoFieldBleed` using `terraform_data.output` as a real unknown ID
  - [x] known sibling does not inherit a prior occupant's sentinel
  - [x] unresolved sibling does not inherit the known prior sibling's sentinel
  - [x] Terraform state, persisted template, and no-op plan
- [x] structural unknown, partial-unknown, null lifecycle, and unknown prior-state coverage
- [x] omitted policy and sibling `system` preservation
- [x] deterministic numeric/non-numeric remote flatten ordering
- [x] `go test ./... -short -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`
- [ ] exact-head GitHub Actions and Codecov (including `golangci-lint v2.11.3`)

Fixes #420
