### PR TITLE
chore: bump go 1.26.6 for GO-2026-6218/6090/5972/5026 stdlib fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/batonogov/terraform-provider-threexui
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/hashicorp/go-version v1.9.0


### PR DESCRIPTION
## Why

CI is red on `main` (run [31783849672](https://github.com/batonogov/terraform-provider-threexui/actions/runs/31783849672)): the `govulncheck ./...` step in the Lint job fails because the pinned `go 1.26.5` toolchain carries four standard-library advisories that are reachable from the provider's HTTP/TLS surface:

| Advisory | Package | Issue | Fixed in |
| --- | --- | --- | --- |
| GO-2026-6218 | `net/url` | quadratic complexity in `resolvePath` | go1.26.6 |
| GO-2026-6090 | `crypto/tls` | unbounded post-handshake message flood | go1.26.6 |
| GO-2026-5972 | `encoding/asn1` | unbounded recursion depth | go1.26.6 |
| GO-2026-5026 | `net/http` | IDNA ASCII-only Punycode label rejection | go1.26.6 |

All four land squarely on the provider's own attack surface (`Client.fetchCSRFToken` → `http.Client.Do` → TLS handshake / URL parsing), so govulncheck flags them at symbol level and every PR now fails the Lint job.

## What

Bump the `go` directive in `go.mod` from 1.26.5 → 1.26.6 — the same pattern as 1cc8796 (`chore: bump go 1.26.5 for GO-2026-5856`). No dependency changes; `go.sum` is untouched.

## Verification

- [x] `go build ./...` — OK
- [x] `go vet ./...` — OK
- [x] `gofmt -l main.go provider` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `task test:unit` — all pass (12.9s)
- [x] `govulncheck ./...` with the 1.26.6 toolchain — **No vulnerabilities found** (symbol level: 0 affected)

## Notes

- The acceptance-test jobs (`task test:acc`, compat matrix) are `needs: [lint]` on this same workflow, so the red Lint job also masks the acc-test results on `main` — this PR unblocks the whole CI pipeline.
- Runtime behavior is unchanged; this is a toolchain security fix only.